### PR TITLE
58 - added an ugly workaround that fixes the issue. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "description": "*Awesome drag and drop library for Svelte 3 (not using the browser's built in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "dependencies": {
     "acorn": "^7.1.1",
     "builtin-modules": "^3.1.0",

--- a/src/action.js
+++ b/src/action.js
@@ -52,6 +52,7 @@ function unregisterDropZone(dropZoneEl, type) {
 
 /* functions to manage observing the dragged element and trigger custom drag-events */
 function watchDraggedElement() {
+    console.debug('watching dragged element');
     armWindowScroller();
     const dropZones = typeToDropZones.get(draggedElType);
     for (const dz of dropZones) {
@@ -65,6 +66,7 @@ function watchDraggedElement() {
     observe(draggedEl, dropZones, observationIntervalMs);
 }
 function unWatchDraggedElement() {
+    console.debug('unwatching dragged element');
     disarmWindowScroller();
     const dropZones = typeToDropZones.get(draggedElType);
     for (const dz of dropZones) {
@@ -278,6 +280,7 @@ export function dndzone(node, options) {
         // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after Svelte removes it
         window.setTimeout(() => {
             document.body.appendChild(draggedEl);
+            watchDraggedElement();
             hideOriginalDragTarget(originalDragTarget);
             document.body.appendChild(originalDragTarget);
         }, 0);
@@ -296,7 +299,6 @@ export function dndzone(node, options) {
         window.addEventListener('touchmove', handleMouseMove, {passive: false, capture: false});
         window.addEventListener('mouseup', handleDrop, {passive: false});
         window.addEventListener('touchend', handleDrop, {passive: false});
-        watchDraggedElement();
     }
 
     function configure({items = [], flipDurationMs:dropAnimationDurationMs = 0, type:newType = DEFAULT_DROP_ZONE_TYPE, dragDisabled = false, dropFromOthersDisabled = false, ...rest }) {

--- a/src/action.js
+++ b/src/action.js
@@ -7,13 +7,15 @@ import {
     styleDraggable,
     styleShadowEl,
     styleActiveDropZones,
-    styleInActiveDropZones
+    styleInActiveDropZones,
+    hideOriginalDragTarget
 } from "./helpers/styler";
 import { DRAGGED_ENTERED_EVENT_NAME, DRAGGED_LEFT_EVENT_NAME, DRAGGED_LEFT_DOCUMENT_EVENT_NAME, DRAGGED_OVER_INDEX_EVENT_NAME, dispatchConsiderEvent, dispatchFinalizeEvent } from './helpers/dispatcher';
 const DEFAULT_DROP_ZONE_TYPE = '--any--';
 const MIN_OBSERVATION_INTERVAL_MS = 100;
 const MIN_MOVEMENT_BEFORE_DRAG_START_PX = 3;
 
+let originalDragTarget;
 let draggedEl;
 let draggedElData;
 let draggedElType;
@@ -187,7 +189,9 @@ function animateDraggedToFinalPosition(callback) {
 /* cleanup */
 function cleanupPostDrop() {
     draggedEl.remove();
+    originalDragTarget.remove();
     draggedEl = undefined;
+    originalDragTarget = undefined;
     draggedElData = undefined;
     draggedElType = undefined;
     originDropZone = undefined;
@@ -215,8 +219,6 @@ export function dndzone(node, options) {
     const config =  {items: [], type: undefined, flipDurationMs: 0, dragDisabled: false, dropFromOthersDisabled: false};
     console.debug("dndzone good to go", {node, options, config});
     let elToIdx = new Map();
-    // used before the actual drag starts
-    let potentialDragTarget;
 
     function addMaybeListeners() {
         window.addEventListener('mousemove', handleMouseMoveMaybeDragStart, {passive: false});
@@ -232,7 +234,7 @@ export function dndzone(node, options) {
     }
     function handleFalseAlarm() {
         removeMaybeListeners();
-        potentialDragTarget = undefined;
+        originalDragTarget = undefined;
         dragStartMousePosition = undefined;
         currentMousePosition = undefined;
     }
@@ -243,20 +245,19 @@ export function dndzone(node, options) {
         currentMousePosition = {x: c.clientX, y: c.clientY};
         if(Math.abs(currentMousePosition.x - dragStartMousePosition.x) >= MIN_MOVEMENT_BEFORE_DRAG_START_PX || Math.abs(currentMousePosition.y - dragStartMousePosition.y) >= MIN_MOVEMENT_BEFORE_DRAG_START_PX) {
             removeMaybeListeners();
-            handleDragStart(potentialDragTarget);
-            potentialDragTarget = undefined;
+            handleDragStart(originalDragTarget);
         }
     }
     function handleMouseDown(e) {
         const c = e.touches? e.touches[0] : e;
         dragStartMousePosition = {x: c.clientX, y:c.clientY};
         currentMousePosition = {...dragStartMousePosition};
-        potentialDragTarget = e.currentTarget;
+        originalDragTarget = e.currentTarget;
         addMaybeListeners();
     }
 
-    function handleDragStart(dragTarget) {
-        console.debug('drag start', dragTarget, {config});
+    function handleDragStart() {
+        console.debug('drag start', originalDragTarget, {config});
         if (isWorkingOnPreviousDrag) {
             console.debug('cannot start a new drag before finalizing previous one');
             return;
@@ -264,24 +265,30 @@ export function dndzone(node, options) {
         isWorkingOnPreviousDrag = true;
 
         // initialising globals
-        const currentIdx = elToIdx.get(dragTarget);
+        const currentIdx = elToIdx.get(originalDragTarget);
         originIndex = currentIdx;
-        originDropZone = dragTarget.parentNode;
+        originDropZone = originalDragTarget.parentElement;
         const {items, type} = config;
         draggedElData = {...items[currentIdx]};
         draggedElType = type;
         shadowElData = {...draggedElData, isDndShadowItem: true};
 
         // creating the draggable element
-        draggedEl = createDraggedElementFrom(dragTarget);
-        document.body.appendChild(draggedEl);
+        draggedEl = createDraggedElementFrom(originalDragTarget);
+        // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after Svelte removes it
+        window.setTimeout(() => {
+            document.body.appendChild(draggedEl);
+            hideOriginalDragTarget(originalDragTarget);
+            document.body.appendChild(originalDragTarget);
+        }, 0);
+
         styleActiveDropZones(
             Array.from(typeToDropZones.get(config.type))
             .filter(dz => dz === originDropZone || !dzToConfig.get(dz).dropFromOthersDisabled)
         );
 
         // removing the original element by removing its data entry
-        items.splice( currentIdx, 1);
+        items.splice(currentIdx, 1);
         dispatchConsiderEvent(originDropZone, items);
 
         // handing over to global handlers - starting to watch the element

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -16,6 +16,8 @@ function trs(property) {
 export function createDraggedElementFrom(originalElement) {
     const rect = originalElement.getBoundingClientRect();
     const draggedEl = originalElement.cloneNode(true);
+    draggedEl.id = `svelte-dnd-action-dragged-el`;
+    draggedEl.name = `svelte-dnd-action-dragged-el`;
     draggedEl.style.position = "fixed";
     draggedEl.style.top = `${rect.top}px`;
     draggedEl.style.left = `${rect.left}px`;
@@ -83,6 +85,16 @@ export function styleDraggable(draggableEl, dragDisabled) {
     draggableEl.ondragstart = () => false;
     draggableEl.style.userSelect = 'none';
     draggableEl.style.cursor = dragDisabled? '': 'grab';
+}
+
+/**
+ * Hides the provided element so that it can stay in the dom without interrupting
+ * @param {HTMLElement} dragTarget
+ */
+export function hideOriginalDragTarget(dragTarget) {
+    dragTarget.style.display = 'none';
+    dragTarget.style.position = 'fixed';
+    dragTarget.style.zIndex = '-5';
 }
 
 /**


### PR DESCRIPTION
We keep the original element in the dom so we don't interrupt the flow of touch events and remove it when drag ends

fixes #58 