### PR TITLE
Add dropTargetStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ An options-object with the following attributes:
 - `type`: Optional. String. dnd-zones that share the same type can have elements from one dragged into another. By default all dnd-zones have the same type. 
 - `dragDisabled`: Optional. Boolean. Setting it to true will make it impossible to drag elements out of the dnd-zone. You can change it at any time, and the zone will adjust on the fly.
 - `dropFromOthersDisabled`: Optional. Boolean. Setting it to true will make it impossible to drop elements from other dnd-zones of the same type. Can be useful if you want to limit the max number of items for example. You can change it at any time, and the zone will adjust on the fly.   
+- `dropTargetStyle`: Optional. Object. An object of styles to apply to the dnd-zone when items can be dragged in to it.
 
 #### Output:
 The action dispatches two custom events:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ An options-object with the following attributes:
 - `type`: Optional. String. dnd-zones that share the same type can have elements from one dragged into another. By default all dnd-zones have the same type. 
 - `dragDisabled`: Optional. Boolean. Setting it to true will make it impossible to drag elements out of the dnd-zone. You can change it at any time, and the zone will adjust on the fly.
 - `dropFromOthersDisabled`: Optional. Boolean. Setting it to true will make it impossible to drop elements from other dnd-zones of the same type. Can be useful if you want to limit the max number of items for example. You can change it at any time, and the zone will adjust on the fly.   
-- `dropTargetStyle`: Optional. Object. An object of styles to apply to the dnd-zone when items can be dragged in to it.
+- `dropTargetStyle`: Optional. Object. An object of styles to apply to the dnd-zone when items can be dragged in to it. Note: the styles override any inline styles applied to the dnd-zone. When the styles are removed, any original inline styles will be lost.
 
 #### Output:
 The action dispatches two custom events:

--- a/src/action.js
+++ b/src/action.js
@@ -14,7 +14,7 @@ import { DRAGGED_ENTERED_EVENT_NAME, DRAGGED_LEFT_EVENT_NAME, DRAGGED_LEFT_DOCUM
 const DEFAULT_DROP_ZONE_TYPE = '--any--';
 const MIN_OBSERVATION_INTERVAL_MS = 100;
 const MIN_MOVEMENT_BEFORE_DRAG_START_PX = 3;
-const DEFAULT_ACTIVE_STYLES = {
+const DEFAULT_DROP_TARGET_STYLE = {
     outline: 'rgba(255, 255, 102, 0.7) solid 2px',
 };
 
@@ -144,7 +144,7 @@ function handleDrop() {
     if (!!shadowElDropZone) { // it was dropped in a drop-zone
         console.debug('dropped in dz', shadowElDropZone);
         let {items, type} = dzToConfig.get(shadowElDropZone);
-        styleInActiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).activeStyle);
+        styleInActiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).dropTargetStyle);
         items = items.map(item => item.hasOwnProperty('isDndShadowItem')? draggedElData : item);
         function finalizeWithinZone() {
             dispatchFinalizeEvent(shadowElDropZone, items);
@@ -160,7 +160,7 @@ function handleDrop() {
     else { // it needs to return to its place
         console.debug('no dz available');
         let {items, type} = dzToConfig.get(originDropZone);
-        styleInActiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).activeStyle);
+        styleInActiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).dropTargetStyle);
         items.splice(originIndex, 0, shadowElData);
         shadowElDropZone = originDropZone;
         shadowElIdx = originIndex;
@@ -227,7 +227,7 @@ export function dndzone(node, options) {
         flipDurationMs: 0,
         dragDisabled: false,
         dropFromOthersDisabled: false,
-        activeStyle: DEFAULT_ACTIVE_STYLES,
+        dropTargetStyle: DEFAULT_DROP_TARGET_STYLE,
     };
     console.debug("dndzone good to go", {node, options, config});
     let elToIdx = new Map();
@@ -299,7 +299,7 @@ export function dndzone(node, options) {
         styleActiveDropZones(
             Array.from(typeToDropZones.get(config.type))
             .filter(dz => dz === originDropZone || !dzToConfig.get(dz).dropFromOthersDisabled),
-            dz => dzToConfig.get(dz).activeStyle,
+            dz => dzToConfig.get(dz).dropTargetStyle,
         );
 
         // removing the original element by removing its data entry
@@ -319,7 +319,7 @@ export function dndzone(node, options) {
         type:newType = DEFAULT_DROP_ZONE_TYPE,
         dragDisabled = false,
         dropFromOthersDisabled = false,
-        activeStyle = DEFAULT_ACTIVE_STYLES,
+        dropTargetStyle = DEFAULT_DROP_TARGET_STYLE,
          ...rest
      }) {
         if (Object.keys(rest).length > 0) {
@@ -336,13 +336,13 @@ export function dndzone(node, options) {
 
         config.dragDisabled = dragDisabled;
 
-        config.activeStyle = activeStyle;
+        config.dropTargetStyle = dropTargetStyle;
 
         if (isWorkingOnPreviousDrag && config.dropFromOthersDisabled !== dropFromOthersDisabled) {
             if (dropFromOthersDisabled) {
-                styleInActiveDropZones([node], dz => dzToConfig.get(dz).activeStyle);
+                styleInActiveDropZones([node], dz => dzToConfig.get(dz).dropTargetStyle);
             } else {
-                styleActiveDropZones([node], dz => dzToConfig.get(dz).activeStyle);
+                styleActiveDropZones([node], dz => dzToConfig.get(dz).dropTargetStyle);
             }
         }
         config.dropFromOthersDisabled = dropFromOthersDisabled;

--- a/src/action.js
+++ b/src/action.js
@@ -14,6 +14,9 @@ import { DRAGGED_ENTERED_EVENT_NAME, DRAGGED_LEFT_EVENT_NAME, DRAGGED_LEFT_DOCUM
 const DEFAULT_DROP_ZONE_TYPE = '--any--';
 const MIN_OBSERVATION_INTERVAL_MS = 100;
 const MIN_MOVEMENT_BEFORE_DRAG_START_PX = 3;
+const DEFAULT_ACTIVE_STYLES = {
+    outline: 'rgba(255, 255, 102, 0.7) solid 2px',
+};
 
 let originalDragTarget;
 let draggedEl;
@@ -140,8 +143,8 @@ function handleDrop() {
     moveDraggedElementToWasDroppedState(draggedEl);
     if (!!shadowElDropZone) { // it was dropped in a drop-zone
         console.debug('dropped in dz', shadowElDropZone);
-        let {items, type} = dzToConfig.get(shadowElDropZone);
-        styleInActiveDropZones(typeToDropZones.get(type));
+        let {items, type, activeStyle} = dzToConfig.get(shadowElDropZone);
+        styleInActiveDropZones(typeToDropZones.get(type), activeStyle);
         items = items.map(item => item.hasOwnProperty('isDndShadowItem')? draggedElData : item);
         function finalizeWithinZone() {
             dispatchFinalizeEvent(shadowElDropZone, items);
@@ -156,8 +159,8 @@ function handleDrop() {
     }
     else { // it needs to return to its place
         console.debug('no dz available');
-        let {items, type} = dzToConfig.get(originDropZone);
-        styleInActiveDropZones(typeToDropZones.get(type));
+        let {items, type, activeStyle} = dzToConfig.get(originDropZone);
+        styleInActiveDropZones(typeToDropZones.get(type), activeStyle);
         items.splice(originIndex, 0, shadowElData);
         shadowElDropZone = originDropZone;
         shadowElIdx = originIndex;
@@ -218,7 +221,14 @@ function cleanupPostDrop() {
  * @return {{update: function, destroy: function}}
  */
 export function dndzone(node, options) {
-    const config =  {items: [], type: undefined, flipDurationMs: 0, dragDisabled: false, dropFromOthersDisabled: false};
+    const config =  {
+        items: [],
+        type: undefined,
+        flipDurationMs: 0,
+        dragDisabled: false,
+        dropFromOthersDisabled: false,
+        activeStyle: DEFAULT_ACTIVE_STYLES,
+    };
     console.debug("dndzone good to go", {node, options, config});
     let elToIdx = new Map();
 
@@ -271,7 +281,7 @@ export function dndzone(node, options) {
         const currentIdx = elToIdx.get(originalDragTarget);
         originIndex = currentIdx;
         originDropZone = originalDragTarget.parentElement;
-        const {items, type} = config;
+        const {items, type, activeStyle} = config;
         draggedElData = {...items[currentIdx]};
         draggedElType = type;
         shadowElData = {...draggedElData, isDndShadowItem: true};
@@ -288,7 +298,8 @@ export function dndzone(node, options) {
 
         styleActiveDropZones(
             Array.from(typeToDropZones.get(config.type))
-            .filter(dz => dz === originDropZone || !dzToConfig.get(dz).dropFromOthersDisabled)
+            .filter(dz => dz === originDropZone || !dzToConfig.get(dz).dropFromOthersDisabled),
+            activeStyle
         );
 
         // removing the original element by removing its data entry
@@ -302,7 +313,15 @@ export function dndzone(node, options) {
         window.addEventListener('touchend', handleDrop, {passive: false});
     }
 
-    function configure({items = [], flipDurationMs:dropAnimationDurationMs = 0, type:newType = DEFAULT_DROP_ZONE_TYPE, dragDisabled = false, dropFromOthersDisabled = false, ...rest }) {
+    function configure({
+        items = [],
+        flipDurationMs:dropAnimationDurationMs = 0,
+        type:newType = DEFAULT_DROP_ZONE_TYPE,
+        dragDisabled = false,
+        dropFromOthersDisabled = false,
+        activeStyle = DEFAULT_ACTIVE_STYLES,
+         ...rest
+     }) {
         if (Object.keys(rest).length > 0) {
             console.warn(`dndzone will ignore unknown options`, rest);
         }
@@ -317,11 +336,13 @@ export function dndzone(node, options) {
 
         config.dragDisabled = dragDisabled;
 
+        config.activeStyle = activeStyle;
+
         if (isWorkingOnPreviousDrag && config.dropFromOthersDisabled !== dropFromOthersDisabled) {
             if (dropFromOthersDisabled) {
-                styleInActiveDropZones([node]);
+                styleInActiveDropZones([node], config.activeStyle);
             } else {
-                styleActiveDropZones([node]);
+                styleActiveDropZones([node], config.activeStyle);
             }
         }
         config.dropFromOthersDisabled = dropFromOthersDisabled;

--- a/src/action.js
+++ b/src/action.js
@@ -143,8 +143,8 @@ function handleDrop() {
     moveDraggedElementToWasDroppedState(draggedEl);
     if (!!shadowElDropZone) { // it was dropped in a drop-zone
         console.debug('dropped in dz', shadowElDropZone);
-        let {items, type, activeStyle} = dzToConfig.get(shadowElDropZone);
-        styleInActiveDropZones(typeToDropZones.get(type), activeStyle);
+        let {items, type} = dzToConfig.get(shadowElDropZone);
+        styleInActiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).activeStyle);
         items = items.map(item => item.hasOwnProperty('isDndShadowItem')? draggedElData : item);
         function finalizeWithinZone() {
             dispatchFinalizeEvent(shadowElDropZone, items);
@@ -159,8 +159,8 @@ function handleDrop() {
     }
     else { // it needs to return to its place
         console.debug('no dz available');
-        let {items, type, activeStyle} = dzToConfig.get(originDropZone);
-        styleInActiveDropZones(typeToDropZones.get(type), activeStyle);
+        let {items, type} = dzToConfig.get(originDropZone);
+        styleInActiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).activeStyle);
         items.splice(originIndex, 0, shadowElData);
         shadowElDropZone = originDropZone;
         shadowElIdx = originIndex;
@@ -281,7 +281,7 @@ export function dndzone(node, options) {
         const currentIdx = elToIdx.get(originalDragTarget);
         originIndex = currentIdx;
         originDropZone = originalDragTarget.parentElement;
-        const {items, type, activeStyle} = config;
+        const {items, type} = config;
         draggedElData = {...items[currentIdx]};
         draggedElType = type;
         shadowElData = {...draggedElData, isDndShadowItem: true};
@@ -299,7 +299,7 @@ export function dndzone(node, options) {
         styleActiveDropZones(
             Array.from(typeToDropZones.get(config.type))
             .filter(dz => dz === originDropZone || !dzToConfig.get(dz).dropFromOthersDisabled),
-            activeStyle
+            dz => dzToConfig.get(dz).activeStyle,
         );
 
         // removing the original element by removing its data entry
@@ -340,9 +340,9 @@ export function dndzone(node, options) {
 
         if (isWorkingOnPreviousDrag && config.dropFromOthersDisabled !== dropFromOthersDisabled) {
             if (dropFromOthersDisabled) {
-                styleInActiveDropZones([node], config.activeStyle);
+                styleInActiveDropZones([node], dz => dzToConfig.get(dz).activeStyle);
             } else {
-                styleActiveDropZones([node], config.activeStyle);
+                styleActiveDropZones([node], dz => dzToConfig.get(dz).activeStyle);
             }
         }
         config.dropFromOthersDisabled = dropFromOthersDisabled;

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -115,9 +115,11 @@ export function styleShadowEl(shadowEl) {
  * will mark the given dropzones as visually active
  * @param {Array<HTMLElement>} dropZones
  */
-export function styleActiveDropZones(dropZones) {
+export function styleActiveDropZones(dropZones, styles) {
     dropZones.forEach(dz => {
-        dz.style.outline = 'rgba(255, 255, 102, 0.7) solid 2px';
+        Object.keys(styles).forEach(style => {
+            dz.style[style] = styles[style];
+        });
     });
 }
 
@@ -125,8 +127,10 @@ export function styleActiveDropZones(dropZones) {
  * will remove the 'active' styling from given dropzones
  * @param {Array<HTMLElement>} dropZones
  */
-export function styleInActiveDropZones(dropZones) {
+export function styleInActiveDropZones(dropZones, styles) {
     dropZones.forEach(dz => {
-        dz.style.outline = '';
+        Object.keys(styles).forEach(style => {
+            dz.style[style] = '';
+        });
     });
 }

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -114,6 +114,7 @@ export function styleShadowEl(shadowEl) {
 /**
  * will mark the given dropzones as visually active
  * @param {Array<HTMLElement>} dropZones
+ * @param {Function} getStyles
  */
 export function styleActiveDropZones(dropZones, getStyles) {
     dropZones.forEach(dz => {
@@ -127,6 +128,7 @@ export function styleActiveDropZones(dropZones, getStyles) {
 /**
  * will remove the 'active' styling from given dropzones
  * @param {Array<HTMLElement>} dropZones
+ * @param {Function} getStyles
  */
 export function styleInActiveDropZones(dropZones, getStyles) {
     dropZones.forEach(dz => {

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -115,8 +115,9 @@ export function styleShadowEl(shadowEl) {
  * will mark the given dropzones as visually active
  * @param {Array<HTMLElement>} dropZones
  */
-export function styleActiveDropZones(dropZones, styles) {
+export function styleActiveDropZones(dropZones, getStyles) {
     dropZones.forEach(dz => {
+        const styles = getStyles(dz)
         Object.keys(styles).forEach(style => {
             dz.style[style] = styles[style];
         });
@@ -127,8 +128,9 @@ export function styleActiveDropZones(dropZones, styles) {
  * will remove the 'active' styling from given dropzones
  * @param {Array<HTMLElement>} dropZones
  */
-export function styleInActiveDropZones(dropZones, styles) {
+export function styleInActiveDropZones(dropZones, getStyles) {
     dropZones.forEach(dz => {
+        const styles = getStyles(dz)
         Object.keys(styles).forEach(style => {
             dz.style[style] = '';
         });


### PR DESCRIPTION
Per #81:

- [x] JSDoc added
- [x] README.md updated
- [x] Uses `dropTargetStyle` for the name
- [ ] Backup styles and reapply them
- [x] Each dnd-zone is styled by it's own config
- [x] Existence of the option overrides the default styles