### PR TITLE
152 - fixed the typo "keyDown" instead of "keydown" that was causing the issue. unrelated: removed un-needed name attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dist"
   ],
   "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -18,7 +18,6 @@ export function createDraggedElementFrom(originalElement) {
     const draggedEl = originalElement.cloneNode(true);
     copyStylesFromTo(originalElement, draggedEl);
     draggedEl.id = `dnd-action-dragged-el`;
-    draggedEl.name = `dnd-action-dragged-el`;
     draggedEl.style.position = "fixed";
     draggedEl.style.top = `${rect.top}px`;
     draggedEl.style.left = `${rect.left}px`;

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -253,14 +253,14 @@ export function dndzone(node, options) {
         registerDropZone(node, newType);
         dzToConfig.set(node, config);
 
-        for(let i=0; i < node.children.length ; i++) {
+        for (let i = 0; i < node.children.length ; i++) {
             const draggableEl = node.children[i];
             allDragTargets.add(draggableEl);
             draggableEl.tabIndex = (isDragging) ? -1 : 0;
             if (!autoAriaDisabled) {
                 draggableEl.setAttribute("role", "listitem");
             }
-            draggableEl.removeEventListener("keyDown", elToKeyDownListeners.get(draggableEl));
+            draggableEl.removeEventListener("keydown", elToKeyDownListeners.get(draggableEl));
             draggableEl.removeEventListener("click", elToFocusListeners.get(draggableEl));
             if (!dragDisabled) {
                 draggableEl.addEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
fixes #152 