### PR TITLE
Include Safari's webkitUserSelect

### DIFF
--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -108,11 +108,11 @@ export function styleDraggable(draggableEl, dragDisabled) {
     draggableEl.ondragstart = () => false;
     if (!dragDisabled) {
         draggableEl.style.userSelect = "none";
-        draggableEl.style.webkitUserSelect = "none";
+        draggableEl.style.WebkitUserSelect = "none";
         draggableEl.style.cursor = "grab";
     } else {
         draggableEl.style.userSelect = "";
-        draggableEl.style.webkitUserSelect = "";
+        draggableEl.style.WebkitUserSelect = "";
         draggableEl.style.cursor = "";
     }
 }

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -108,9 +108,11 @@ export function styleDraggable(draggableEl, dragDisabled) {
     draggableEl.ondragstart = () => false;
     if (!dragDisabled) {
         draggableEl.style.userSelect = "none";
+        draggableEl.style.webkitUserSelect = "none";
         draggableEl.style.cursor = "grab";
     } else {
         draggableEl.style.userSelect = "";
+        draggableEl.style.webkitUserSelect = "";
         draggableEl.style.cursor = "";
     }
 }


### PR DESCRIPTION
This fixes some bugs I've experienced while dragging items in Safari.

Edit: I should have mentioned that Safari needing the "webkit" prefix on this property in Javascript is [documented here](https://www.w3schools.com/jsref/prop_style_userselect.asp).