### PR TITLE
188 dragging small over large

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ node_modules
 cypress/videos
 cypress/screenshots
 
-
-
+/.eslintcache

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.6.22",
+    "version": "0.6.23",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,8 @@ export const SOURCES = {
 };
 
 export const SHADOW_ITEM_MARKER_PROPERTY_NAME = "isDndShadowItem";
+export const SHADOW_ELEMENT_ATTRIBUTE_NAME = "data-is-dnd-shadow-item";
+
 export let ITEM_ID_KEY = "id";
 let activeDndZoneCount = 0;
 export function incrementActiveDropZoneCount() {

--- a/src/helpers/intersection.js
+++ b/src/helpers/intersection.js
@@ -49,7 +49,7 @@ function adjustedBoundingRect(el) {
  * @param {HTMLElement} el
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
-function getAbsoluteRectNoTransforms(el) {
+export function getAbsoluteRectNoTransforms(el) {
     const rect = adjustedBoundingRect(el);
     return {
         top: rect.top + window.scrollY,
@@ -108,7 +108,7 @@ function calcDistance(pointA, pointB) {
  * @param {Rect} rect
  * @return {boolean|boolean}
  */
-function isPointInsideRect(point, rect) {
+export function isPointInsideRect(point, rect) {
     return point.y <= rect.bottom && point.y >= rect.top && point.x >= rect.left && point.x <= rect.right;
 }
 

--- a/src/helpers/listUtil.js
+++ b/src/helpers/listUtil.js
@@ -2,12 +2,22 @@ import {isCenterOfAInsideB, calcDistanceBetweenCenters, getAbsoluteRectNoTransfo
 import {printDebug, SHADOW_ELEMENT_ATTRIBUTE_NAME} from "../constants";
 
 let dzToShadowIndexToRect;
+
+/**
+ * Resets the cache that allows for smarter "would be index" resolution. Should be called after every drag operation
+ */
 export function resetIndexesCache() {
     printDebug(() => "resetting indexes cache");
     dzToShadowIndexToRect = new Map();
 }
 resetIndexesCache();
 
+/**
+ * Caches the coordinates of the shadow element when it's in a certain index in a certain dropzone.
+ * Helpful in order to determine "would be index" more effectively
+ * @param {HTMLElement} dz
+ * @return {number} - the shadow element index
+ */
 function cacheShadowRect(dz) {
     const shadowElIndex = Array.from(dz.children).findIndex(child => child.getAttribute(SHADOW_ELEMENT_ATTRIBUTE_NAME));
     if (shadowElIndex >= 0) {
@@ -15,8 +25,9 @@ function cacheShadowRect(dz) {
             dzToShadowIndexToRect.set(dz, new Map());
         }
         dzToShadowIndexToRect.get(dz).set(shadowElIndex, getAbsoluteRectNoTransforms(dz.children[shadowElIndex]));
+        return shadowElIndex;
     }
-    return shadowElIndex;
+    return undefined;
 }
 
 /**

--- a/src/helpers/observer.js
+++ b/src/helpers/observer.js
@@ -1,4 +1,4 @@
-import {findWouldBeIndex} from "./listUtil";
+import {findWouldBeIndex, resetIndexesCache} from "./listUtil";
 import {findCenterOfElement, isElementOffDocument} from "./intersection";
 import {
     dispatchDraggedElementEnteredContainer,
@@ -95,4 +95,5 @@ export function unobserve() {
     printDebug(() => "unobserving");
     clearTimeout(next);
     resetScrolling();
+    resetIndexesCache();
 }

--- a/src/helpers/observer.js
+++ b/src/helpers/observer.js
@@ -68,7 +68,6 @@ export function observe(draggedEl, dropZones, intervalMs = INTERVAL_MS) {
                 lastDropZoneFound && dispatchDraggedElementLeftContainer(lastDropZoneFound, draggedEl);
                 dispatchDraggedElementEnteredContainer(dz, indexObj, draggedEl);
                 lastDropZoneFound = dz;
-                lastIndexFound = index;
             } else if (index !== lastIndexFound) {
                 dispatchDraggedElementIsOverIndex(dz, indexObj, draggedEl);
                 lastIndexFound = index;

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -1,3 +1,5 @@
+import {SHADOW_ELEMENT_ATTRIBUTE_NAME} from "../constants";
+
 const TRANSITION_DURATION_SECONDS = 0.2;
 
 /**
@@ -131,8 +133,18 @@ export function hideOriginalDragTarget(dragTarget) {
  * styles the shadow element
  * @param {HTMLElement} shadowEl
  */
-export function styleShadowEl(shadowEl) {
+export function decorateShadowEl(shadowEl) {
     shadowEl.style.visibility = "hidden";
+    shadowEl.setAttribute(SHADOW_ELEMENT_ATTRIBUTE_NAME, "true");
+}
+
+/**
+ * undo the styles the shadow element
+ * @param {HTMLElement} shadowEl
+ */
+export function unDecorateShadowElement(shadowEl) {
+    shadowEl.style.visibility = "";
+    shadowEl.removeAttribute(SHADOW_ELEMENT_ATTRIBUTE_NAME);
 }
 
 /**

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -13,10 +13,11 @@ import {
     moveDraggedElementToWasDroppedState,
     morphDraggedElementToBeLike,
     styleDraggable,
-    styleShadowEl,
+    decorateShadowEl,
     styleActiveDropZones,
     styleInactiveDropZones,
-    hideOriginalDragTarget
+    hideOriginalDragTarget,
+    unDecorateShadowElement
 } from "./helpers/styler";
 import {
     DRAGGED_ENTERED_EVENT_NAME,
@@ -193,7 +194,7 @@ function handleDrop() {
                     source: SOURCES.POINTER
                 });
             }
-            shadowElDropZone.children[shadowElIdx].style.visibility = "";
+            unDecorateShadowElement(shadowElDropZone.children[shadowElIdx]);
             cleanupPostDrop();
         };
         animateDraggedToFinalPosition(shadowElIdx, finalizeFunction);
@@ -217,7 +218,7 @@ function handleDrop() {
                 id: draggedElData[ITEM_ID_KEY],
                 source: SOURCES.POINTER
             });
-            shadowElDropZone.children[originIndex].style.visibility = "";
+            unDecorateShadowElement(shadowElDropZone.children[originIndex]);
             cleanupPostDrop();
         };
         window.setTimeout(() => animateDraggedToFinalPosition(originIndex, finalizeFunction), 0);
@@ -410,7 +411,7 @@ export function dndzone(node, options) {
                 morphDraggedElementToBeLike(draggedEl, draggableEl, currentMousePosition.x, currentMousePosition.y, () =>
                     config.transformDraggedElement(draggedEl, draggedElData, idx)
                 );
-                styleShadowEl(draggableEl);
+                decorateShadowEl(draggableEl);
                 continue;
             }
             draggableEl.removeEventListener("mousedown", elToMouseDownListener.get(draggableEl));


### PR DESCRIPTION
added caching for the position of the shadow element in given indexes, which gets reset after every drag operation. this allows to not "get confused" by large element that shouldn't move out of the way.
fixes #188 