### PR TITLE
208 - removing transform when getting the rect for the final animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/src/helpers/intersection.js
+++ b/src/helpers/intersection.js
@@ -1,6 +1,11 @@
 // This is based off https://stackoverflow.com/questions/27745438/how-to-compute-getboundingclientrect-without-considering-transforms/57876601#57876601
 // It removes the transforms that are potentially applied by the flip animations
-function adjustedBoundingRect(el) {
+/**
+ * Gets the bounding rect but removes transforms (ex: flip animation)
+ * @param {HTMLElement} el
+ * @return {{top: number, left: number, bottom: number, right: number}}
+ */
+export function getBoundingRectNoTransforms(el) {
     let ta;
     const rect = el.getBoundingClientRect();
     const style = getComputedStyle(el);
@@ -50,7 +55,7 @@ function adjustedBoundingRect(el) {
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
 export function getAbsoluteRectNoTransforms(el) {
-    const rect = adjustedBoundingRect(el);
+    const rect = getBoundingRectNoTransforms(el);
     return {
         top: rect.top + window.scrollY,
         bottom: rect.bottom + window.scrollY,

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -31,6 +31,7 @@ import {
     DRAGGED_OVER_INDEX_EVENT_NAME
 } from "./helpers/dispatcher";
 import {areObjectsShallowEqual, toString} from "./helpers/util";
+import {getBoundingRectNoTransforms} from "./helpers/intersection";
 
 const DEFAULT_DROP_ZONE_TYPE = "--any--";
 const MIN_OBSERVATION_INTERVAL_MS = 100;
@@ -199,7 +200,10 @@ function handleDrop() {
     unWatchDraggedElement();
     moveDraggedElementToWasDroppedState(draggedEl);
 
-    // it was dropped in a drop-zone
+    if (!shadowElDropZone) {
+        printDebug("element was dropped right after left origin but before entering somewhere else");
+        shadowElDropZone = originDropZone;
+    }
     printDebug(() => ["dropped in dz", shadowElDropZone]);
     let {items, type} = dzToConfig.get(shadowElDropZone);
     styleInactiveDropZones(typeToDropZones.get(type), dz => dzToConfig.get(dz).dropTargetStyle);
@@ -230,7 +234,7 @@ function handleDrop() {
 
 // helper function for handleDrop
 function animateDraggedToFinalPosition(shadowElIdx, callback) {
-    const shadowElRect = shadowElDropZone.children[shadowElIdx].getBoundingClientRect();
+    const shadowElRect = getBoundingRectNoTransforms(shadowElDropZone.children[shadowElIdx]);
     const newTransform = {
         x: shadowElRect.left - parseFloat(draggedEl.style.left),
         y: shadowElRect.top - parseFloat(draggedEl.style.top)


### PR DESCRIPTION
removing transform when getting the rect for the final animation so that the element always animates to the correct place (not misled by ongoing flips)
fixes #208 