### PR TITLE
211 - keeping a shadow item with a temporary id on drag start

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,6 +11,6 @@ It changes some default behaviours (for the better).
 
 ### [v0.7.4](https://github.com/isaacHagoel/svelte-dnd-action/pull/213)
 
-This release introduces a subtle change to the dragStarted event. \*If you are using [Dragula Copy on Drag](https://svelte.dev/repl/924b4cc920524065a637fa910fe10193?version=3.31.2), you will need to update your consider handler (add 1 line of code to remove the newly added shadow placeholder), see linked REPL).
-Starting with this version, the initial consider event (dragStarted) places a placeholder with a new id instead of the dragged item (old behaviour: removing the dragged item from the list all together). The placeholder is replaced with the real shadow element (the one that has the same id as the original item) in the next event (basically instantly).
+This release introduces a subtle change to the dragStarted event. If you are using [Dragula Copy on Drag](https://svelte.dev/repl/924b4cc920524065a637fa910fe10193?version=3.31.2), you will need to update your consider handler (add 1 line of code to remove the newly added shadow placeholder, see linked REPL).
+Starting with this version, the initial consider event (dragStarted) places a placeholder item with a new id instead of the dragged item in the items list (old behaviour: removing the dragged item from the list altogether). The placeholder is replaced with the real shadow element (the one that has the same id as the original item) in the next event (basically instantly).
 This change makes the initial behaviour of large items (relative to their peers) much smoother.

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,9 +2,15 @@
 
 ### [v0.7.0](https://github.com/isaacHagoel/svelte-dnd-action/pull/202)
 
-All of the changes in this release only affect pointer (mouse/ touch) based drag and drop operations.
+All the changes in this release only affect pointer (mouse/ touch) based drag and drop operations.
 It changes some default behaviours (for the better).
 
 -   When an element is being dragged outside of any dnd zone, the placeholder element now appears in the original dnd zone in the original index and indicates where the element would land if dropped. This was added for better UX and to address single sortable list use cases.
 -   This change includes the introduction of two new triggers, that can be intercepted by the `consider` handler: `DRAGGED_LEFT_ALL` which fires when the placeholder is added to the origin dndzone, and `DRAGGED_ENTERED_ANOTHER` which fires when the placeholder is removed from the origin dnd zone.
 -   When drag starts - the library now locks the minimum width and height of the origin dropzone for the duration of the drag operation. This is done in order to prevent the container from shrinking and growing jarringly as the element is dragged around. This is especially helpful when the user drags the last element, which in previous versions could make the dndzone shrink underneath such that the dragged element wasn't over it anymore.
+
+### [v0.7.4](https://github.com/isaacHagoel/svelte-dnd-action/pull/213)
+
+This release introduces a subtle change to the dragStarted event. \*If you are using [Dragula Copy on Drag](https://svelte.dev/repl/924b4cc920524065a637fa910fe10193?version=3.31.2), you will need to update your consider handler (add 1 line of code to remove the newly added shadow placeholder), see linked REPL).
+Starting with this version, the initial consider event (dragStarted) places a placeholder with a new id instead of the dragged item (old behaviour: removing the dragged item from the list all together). The placeholder is replaced with the real shadow element (the one that has the same id as the original item) in the next event (basically instantly).
+This change makes the initial behaviour of large items (relative to their peers) much smoother.

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,7 @@ export const SOURCES = {
 
 export const SHADOW_ITEM_MARKER_PROPERTY_NAME = "isDndShadowItem";
 export const SHADOW_ELEMENT_ATTRIBUTE_NAME = "data-is-dnd-shadow-item";
+export const SHADOW_PLACEHOLDER_ITEM_ID = "id:dnd-shadow-placeholder-0000";
 
 export let ITEM_ID_KEY = "id";
 let activeDndZoneCount = 0;

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -180,13 +180,12 @@ function handleDraggedLeft(e) {
             source: SOURCES.POINTER
         });
     }
-    if (e.currentTarget !== originDropZone) {
-        dispatchConsiderEvent(e.currentTarget, items, {
-            trigger: TRIGGERS.DRAGGED_LEFT,
-            id: draggedElData[ITEM_ID_KEY],
-            source: SOURCES.POINTER
-        });
-    }
+    // for the origin dz, when the dragged is outside of any, this will be fired in addition to the previous. this is for simplicity
+    dispatchConsiderEvent(e.currentTarget, items, {
+        trigger: TRIGGERS.DRAGGED_LEFT,
+        id: draggedElData[ITEM_ID_KEY],
+        source: SOURCES.POINTER
+    });
 }
 function handleDraggedIsOverIndex(e) {
     printDebug(() => ["dragged is over index", e.currentTarget, e.detail]);


### PR DESCRIPTION
keeping a shadow item with a temporary id on drag start, removing on drag entered. this prevents the list from having a missing item, even for an instant and also removes ambiguity about the initial would be index

resolves #211 