### PR TITLE
Fix typo in Typescript instruction snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ declare type DndEvent = import("svelte-dnd-action").DndEvent;
 declare namespace svelte.JSX {
     interface HTMLAttributes<T> {
         onconsider?: (event: CustomEvent<DndEvent> & {target: EventTarget & T}) => void;
-        onfinalize?: (event: CustomeEvent<DndEvent> & {target: EventTarget & T}) => void;
+        onfinalize?: (event: CustomEvent<DndEvent> & {target: EventTarget & T}) => void;
     }
 }
 ```


### PR DESCRIPTION
Fix PR fixes a typo that will cause errors when copying the Typescript code snippet.