### PR TITLE
223 - added a cancelable USER_DROPPED consider event on the origin zone

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const TRIGGERS = {
     DRAGGED_OVER_INDEX: DRAGGED_OVER_INDEX_EVENT_NAME,
     DRAGGED_LEFT: DRAGGED_LEFT_EVENT_NAME,
     DRAGGED_LEFT_ALL: "draggedLeftAll",
+    USER_DROPPED: "userDropped",
     DROPPED_INTO_ZONE: "droppedIntoZone",
     DROPPED_INTO_ANOTHER: "droppedIntoAnother",
     DROPPED_OUTSIDE_OF_ANY: "droppedOutsideOfAny",

--- a/src/helpers/dispatcher.js
+++ b/src/helpers/dispatcher.js
@@ -26,7 +26,7 @@ export function dispatchFinalizeEvent(el, items, info) {
  * @param {Info} info
  */
 export function dispatchConsiderEvent(el, items, info) {
-    el.dispatchEvent(
+    return el.dispatchEvent(
         new CustomEvent(CONSIDER_EVENT_NAME, {
             detail: {items, info}
         })

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -261,7 +261,21 @@ function handleDrop() {
         unDecorateShadowElement(shadowElDropZone.children[shadowElIdx]);
         cleanupPostDrop();
     }
-    animateDraggedToFinalPosition(shadowElIdx, finalizeWithinZone);
+    let shouldFinalizeDrop = true;
+    if (isDraggedOutsideOfAnyDz) {
+        shouldFinalizeDrop = !dispatchConsiderEvent(originDropZone, dzToConfig.get(originDropZone).items, {
+            trigger: TRIGGERS.USER_DROPPED,
+            id: draggedElData[ITEM_ID_KEY],
+            source: SOURCES.POINTER
+        });
+    }
+    if (shouldFinalizeDrop) {
+        printDebug(() => "will animate before finalizing drop");
+        animateDraggedToFinalPosition(shadowElIdx, finalizeWithinZone);
+    } else {
+        finalizeWithinZone();
+        printDebug(() => "dropped outside and event was cancelled, finalizing without animating");
+    }
 }
 
 // helper function for handleDrop


### PR DESCRIPTION
added a cancelable USER_DROPPED consider event on the origin zone if the dragged element was dropped outside of any. cancelling skips the final animation to place and dispatches the finalize events right away.

missing updates to README and types

resolves #223  