### PR TITLE
Allow child buttons to be pressed with keyboard

### DIFF
--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -170,7 +170,7 @@ export function dndzone(node, options) {
             case "Enter":
             case " ": {
                 // we don't want to affect nested input elements or clickable elements
-                if ((e.target.click !== undefined || e.target.value !== undefined || e.target.isContentEditable) && !allDragTargets.has(e.target)) {
+                if ((e.target.disabled !== undefined || e.target.href || e.target.isContentEditable) && !allDragTargets.has(e.target)) {
                     return;
                 }
                 e.preventDefault(); // preventing scrolling on spacebar

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -169,8 +169,8 @@ export function dndzone(node, options) {
         switch (e.key) {
             case "Enter":
             case " ": {
-                // we don't want to affect nested input elements
-                if ((e.target.value !== undefined || e.target.isContentEditable) && !allDragTargets.has(e.target)) {
+                // we don't want to affect nested input elements or clickable elements
+                if ((e.target.click !== undefined || e.target.value !== undefined || e.target.isContentEditable) && !allDragTargets.has(e.target)) {
                     return;
                 }
                 e.preventDefault(); // preventing scrolling on spacebar


### PR DESCRIPTION
**Before**

Notice, how, even though the button is focused, I can't press it with spacebar. Doing so initiates drag mode.

![before](https://user-images.githubusercontent.com/14965732/106985455-1b0ea300-672f-11eb-953a-7b949879257f.gif)

**After**

After the change, I can press fire buttons with spacebar. And I can also initiate drag mode by selecting the containing element.

![after](https://user-images.githubusercontent.com/14965732/106985461-1cd86680-672f-11eb-9614-aac179e03d4b.gif)