### PR TITLE
Use touch coords

### DIFF
--- a/cypress/integration/intersection.spec.js
+++ b/cypress/integration/intersection.spec.js
@@ -1,4 +1,4 @@
-import {isCenterOfAInsideB, calcDistanceBetweenCenters, isElementOffDocument} from "../../src/helpers/intersection";
+import {isPointInsideB, calcDistanceBetweenCenters, isElementOffDocument, findCenterOfElement} from "../../src/helpers/intersection";
 
 function makeDiv(widthPx = 50, heightPx = 50) {
     const el = document.createElement("div");
@@ -8,20 +8,20 @@ function makeDiv(widthPx = 50, heightPx = 50) {
 }
 
 describe("intersection", () => {
-    describe("isCenterOfAInsideB", () => {
+    describe("isPointInsideB", () => {
         it("center is inside", () => {
             const el = makeDiv(50, 50);
             document.body.style.width = "1000px";
             document.body.style.height = "1000px";
             document.body.appendChild(el);
-            expect(isCenterOfAInsideB(el, document.body)).to.equal(true);
+            expect(isPointInsideB(findCenterOfElement(el), document.body)).to.equal(true);
         });
         it("center is outside", () => {
             const elA = makeDiv();
             const elB = makeDiv();
             document.body.appendChild(elA);
             document.body.appendChild(elB);
-            expect(isCenterOfAInsideB(elA, elB)).to.equal(false);
+            expect(isPointInsideB(findCenterOfElement(elA), elB)).to.equal(false);
         });
     });
 
@@ -29,7 +29,7 @@ describe("intersection", () => {
         it("distance from self is zero", () => {
             const el = makeDiv();
             document.body.appendChild(el);
-            expect(calcDistanceBetweenCenters(el, el)).to.equal(0);
+            expect(calcDistanceBetweenCenters(findCenterOfElement(el), el)).to.equal(0);
         });
         it("calculates distance correctly", () => {
             const elA = makeDiv(80, 60);
@@ -40,8 +40,8 @@ describe("intersection", () => {
             elB.left = 0;
             document.body.appendChild(elA);
             elA.appendChild(elB);
-            expect(calcDistanceBetweenCenters(elA, elB)).to.equal(25);
-            expect(calcDistanceBetweenCenters(elB, elA)).to.equal(25);
+            expect(calcDistanceBetweenCenters(findCenterOfElement(elA), elB)).to.equal(25);
+            expect(calcDistanceBetweenCenters(findCenterOfElement(elB), elA)).to.equal(25);
         });
     });
 

--- a/cypress/integration/listUtil.spec.js
+++ b/cypress/integration/listUtil.spec.js
@@ -1,3 +1,4 @@
+import {findCenterOfElement} from "../../src/helpers/intersection";
 import {findWouldBeIndex} from "../../src/helpers/listUtil";
 
 describe("listUtil", () => {
@@ -37,17 +38,17 @@ describe("listUtil", () => {
         it("returns null when element is outside of containers", () => {
             draggedEl.style.top = "600px";
             draggedEl.style.left = "0";
-            expect(findWouldBeIndex(draggedEl, containerEl)).to.equal(null);
+            expect(findWouldBeIndex(findCenterOfElement(draggedEl), containerEl)).to.equal(null);
         });
         it("works correctly, not proximity based", () => {
             draggedEl.style.top = "150px";
             draggedEl.style.left = "5px";
-            expect(findWouldBeIndex(draggedEl, containerEl)).to.deep.equal({index: 1, isProximityBased: false});
+            expect(findWouldBeIndex(findCenterOfElement(draggedEl), containerEl)).to.deep.equal({index: 1, isProximityBased: false});
         });
         it("works correctly, proximity based", () => {
             draggedEl.style.top = "450px";
             draggedEl.style.left = "5px";
-            expect(findWouldBeIndex(draggedEl, containerEl)).to.deep.equal({index: 2, isProximityBased: true});
+            expect(findWouldBeIndex(findCenterOfElement(draggedEl), containerEl)).to.deep.equal({index: 2, isProximityBased: true});
         });
     });
 });

--- a/src/helpers/intersection.js
+++ b/src/helpers/intersection.js
@@ -127,14 +127,13 @@ export function findCenterOfElement(el) {
 }
 
 /**
- * @param {HTMLElement} elA
+ * @param {Point} point
  * @param {HTMLElement} elB
  * @return {boolean}
  */
-export function isCenterOfAInsideB(elA, elB) {
-    const centerOfA = findCenterOfElement(elA);
+export function isPointInsideB(point, elB) {
     const rectOfB = getAbsoluteRectNoTransforms(elB);
-    return isPointInsideRect(centerOfA, rectOfB);
+    return isPointInsideRect(point, rectOfB);
 }
 
 /**
@@ -142,8 +141,7 @@ export function isCenterOfAInsideB(elA, elB) {
  * @param {HTMLElement|ChildNode} elB
  * @return {number}
  */
-export function calcDistanceBetweenCenters(elA, elB) {
-    const centerOfA = findCenterOfElement(elA);
+export function calcDistanceBetweenCenters(centerOfA, elB) {
     const centerOfB = findCenterOfElement(elB);
     return calcDistance(centerOfA, centerOfB);
 }

--- a/src/helpers/listUtil.js
+++ b/src/helpers/listUtil.js
@@ -1,4 +1,4 @@
-import {isCenterOfAInsideB, calcDistanceBetweenCenters, getAbsoluteRectNoTransforms, isPointInsideRect, findCenterOfElement} from "./intersection";
+import {isPointInsideB, calcDistanceBetweenCenters, getAbsoluteRectNoTransforms, isPointInsideRect} from "./intersection";
 import {printDebug, SHADOW_ELEMENT_ATTRIBUTE_NAME} from "../constants";
 
 let dzToShadowIndexToRect;
@@ -36,13 +36,19 @@ function cacheShadowRect(dz) {
  * @property {boolean} isProximityBased - false if the element is actually over the index, true if it is not over it but this index is the closest
  */
 /**
+ * @typedef {Object} Point
+ * @property {number} x
+ * @property {number} y
+ */
+/**
  * Find the index for the dragged element in the list it is dragged over
- * @param {HTMLElement} floatingAboveEl
+ *
+ * @param {Point} point
  * @param {HTMLElement} collectionBelowEl
  * @returns {Index|null} -  if the element is over the container the Index object otherwise null
  */
-export function findWouldBeIndex(floatingAboveEl, collectionBelowEl) {
-    if (!isCenterOfAInsideB(floatingAboveEl, collectionBelowEl)) {
+export function findWouldBeIndex(point, collectionBelowEl) {
+    if (!isPointInsideB(point, collectionBelowEl)) {
         return null;
     }
     const children = collectionBelowEl.children;
@@ -55,10 +61,10 @@ export function findWouldBeIndex(floatingAboveEl, collectionBelowEl) {
     // the search could be more efficient but keeping it simple for now
     // a possible improvement: pass in the lastIndex it was found in and check there first, then expand from there
     for (let i = 0; i < children.length; i++) {
-        if (isCenterOfAInsideB(floatingAboveEl, children[i])) {
+        if (isPointInsideB(point, children[i])) {
             const cachedShadowRect = dzToShadowIndexToRect.has(collectionBelowEl) && dzToShadowIndexToRect.get(collectionBelowEl).get(i);
             if (cachedShadowRect) {
-                if (!isPointInsideRect(findCenterOfElement(floatingAboveEl), cachedShadowRect)) {
+                if (!isPointInsideRect(point, cachedShadowRect)) {
                     return {index: shadowElIndex, isProximityBased: false};
                 }
             }
@@ -71,7 +77,7 @@ export function findWouldBeIndex(floatingAboveEl, collectionBelowEl) {
     let indexOfMin = undefined;
     // we are checking all of them because we don't know whether we are dealing with a horizontal or vertical container and where the floating element entered from
     for (let i = 0; i < children.length; i++) {
-        const distance = calcDistanceBetweenCenters(floatingAboveEl, children[i]);
+        const distance = calcDistanceBetweenCenters(point, children[i]);
         if (distance < minDistanceSoFar) {
             minDistanceSoFar = distance;
             indexOfMin = i;

--- a/src/helpers/observer.js
+++ b/src/helpers/observer.js
@@ -57,7 +57,7 @@ export function observe(draggedEl, dropZones, intervalMs = INTERVAL_MS) {
         // this is a simple algorithm, potential improvement: first look at lastDropZoneFound
         let isDraggedInADropZone = false;
         for (const dz of dropZonesFromDeepToShallow) {
-            const indexObj = findWouldBeIndex(draggedEl, dz);
+            const indexObj = findWouldBeIndex(currentCenterOfDragged, dz);
             if (indexObj === null) {
                 // it is not inside
                 continue;

--- a/src/helpers/observer.js
+++ b/src/helpers/observer.js
@@ -16,13 +16,23 @@ const TOLERANCE_PX = 10;
 const {scrollIfNeeded, resetScrolling} = makeScroller();
 let next;
 
+let mouseX = 0;
+let mouseY = 0;
+
+function onMouseMove(event) {
+    mouseX = event.touches ? event.touches[0].clientX : event.clientX;
+    mouseY = event.touches ? event.touches[0].clientY : event.clientY;
+}
+
 /**
  * Tracks the dragged elements and performs the side effects when it is dragged over a drop zone (basically dispatching custom-events scrolling)
  * @param {Set<HTMLElement>} dropZones
  * @param {HTMLElement} draggedEl
  * @param {number} [intervalMs = INTERVAL_MS]
  */
-export function observe(draggedEl, dropZones, intervalMs = INTERVAL_MS) {
+export function observe(draggedEl, dropZones, intervalMs = INTERVAL_MS, useTouchPosition = false) {
+    document.body.addEventListener("mousemove", onMouseMove);
+    document.body.addEventListener("touchmove", onMouseMove);
     // initialization
     let lastDropZoneFound;
     let lastIndexFound;
@@ -35,7 +45,7 @@ export function observe(draggedEl, dropZones, intervalMs = INTERVAL_MS) {
      * The main function in this module. Tracks where everything is/ should be a take the actions
      */
     function andNow() {
-        const currentCenterOfDragged = findCenterOfElement(draggedEl);
+        const currentCenterOfDragged = useTouchPosition ? {x: mouseX, y: mouseY} : findCenterOfElement(draggedEl);
         const scrolled = scrollIfNeeded(currentCenterOfDragged, lastDropZoneFound);
         // we only want to make a new decision after the element was moved a bit to prevent flickering
         if (
@@ -93,6 +103,8 @@ export function observe(draggedEl, dropZones, intervalMs = INTERVAL_MS) {
 // assumption - we can only observe one dragged element at a time, this could be changed in the future
 export function unobserve() {
     printDebug(() => "unobserving");
+    document.body.removeEventListener("mousemove", onMouseMove);
+    document.body.removeEventListener("touchmove", onMouseMove);
     clearTimeout(next);
     resetScrolling();
     resetIndexesCache();

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -98,7 +98,11 @@ function watchDraggedElement() {
         MIN_OBSERVATION_INTERVAL_MS,
         ...Array.from(dropZones.keys()).map(dz => dzToConfig.get(dz).dropAnimationDurationMs)
     );
-    observe(draggedEl, dropZones, observationIntervalMs * 1.07);
+    const useTouchPosition = Array.from(dropZones.keys())
+        .map(dz => dzToConfig.get(dz).useTouchPosition)
+        .find(use => use);
+
+    observe(draggedEl, dropZones, observationIntervalMs * 1.07, useTouchPosition);
 }
 function unWatchDraggedElement() {
     printDebug(() => "unwatching dragged element");
@@ -425,7 +429,8 @@ export function dndzone(node, options) {
         dropFromOthersDisabled = false,
         dropTargetStyle = DEFAULT_DROP_TARGET_STYLE,
         dropTargetClasses = [],
-        transformDraggedElement = () => {}
+        transformDraggedElement = () => {},
+        useTouchPosition = false
     }) {
         config.dropAnimationDurationMs = dropAnimationDurationMs;
         if (config.type && newType !== config.type) {
@@ -437,6 +442,7 @@ export function dndzone(node, options) {
         config.items = [...items];
         config.dragDisabled = dragDisabled;
         config.transformDraggedElement = transformDraggedElement;
+        config.useTouchPosition = useTouchPosition;
 
         // realtime update for dropTargetStyle
         if (


### PR DESCRIPTION
Hi, first thanks for this awesome library.

When using it on mobile (touch devices), especially with bigger drag elements it can be difficult to put the center of the drag element inside a drop zone.

This PR allows to switch between the default behavior (of using the center of the dragged element) and using the mouse/touch coordinate to check the underlying drop zone.

The first commit adjust the code a bit so that both cases can be handled by the code.   
The second commit adds the new behavior and config options.