### PR TITLE
Don't add tab index to empty drop zones

### DIFF
--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -290,7 +290,7 @@ export function dndzone(node, options) {
         dzToConfig.set(node, config);
 
         node.tabIndex =
-            config.items.length === 0 ||
+            (!isDragging && config.items.length === 0) ||
             (isDragging &&
                 (node === focusedDz ||
                     focusedItem.contains(node) ||

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -290,11 +290,12 @@ export function dndzone(node, options) {
         dzToConfig.set(node, config);
 
         node.tabIndex =
-            isDragging &&
-            (node === focusedDz ||
-                focusedItem.contains(node) ||
-                config.dropFromOthersDisabled ||
-                (focusedDz && config.type !== dzToConfig.get(focusedDz).type))
+            !isDragging ||
+            (isDragging &&
+                (node === focusedDz ||
+                    focusedItem.contains(node) ||
+                    config.dropFromOthersDisabled ||
+                    (focusedDz && config.type !== dzToConfig.get(focusedDz).type)))
                 ? -1
                 : 0;
         node.addEventListener("focus", handleZoneFocus);

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -290,7 +290,7 @@ export function dndzone(node, options) {
         dzToConfig.set(node, config);
 
         node.tabIndex =
-            !isDragging ||
+            config.items.length === 0 ||
             (isDragging &&
                 (node === focusedDz ||
                     focusedItem.contains(node) ||


### PR DESCRIPTION
Currently, `tabindex = 0` is being added to the drop zone even when no element is being dragged: https://github.com/isaacHagoel/svelte-dnd-action/blob/da059e626153eecacc7a9d4b5ec49018827e398a/src/keyboardAction.js#L292-L299

Then, in the focus handler, we do nothing if dragging is not in progress: https://github.com/isaacHagoel/svelte-dnd-action/blob/da059e626153eecacc7a9d4b5ec49018827e398a/src/keyboardAction.js#L85-L87

I don't think it makes sense to make an element focusable if we do nothing when it takes focus. Plus, it leads to weird styling on empty lists. (See screenshot below.)

![image](https://user-images.githubusercontent.com/14965732/107136854-7033eb80-68cc-11eb-91a2-c9aad16924e2.png)