### PR TITLE
Adds customStartEvent option

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -52,6 +52,7 @@ function validateOptions(options) {
         transformDraggedElement,
         autoAriaDisabled,
         centreDraggedOnCursor,
+        customStartEvent,
         ...rest
     } = options;
     /*eslint-enable*/

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -30,6 +30,7 @@ export interface Options {
     transformDraggedElement?: TransformDraggedElementFunction;
     autoAriaDisabled?: boolean;
     centreDraggedOnCursor?: boolean;
+    customStartEvent?: String;
 }
 
 /**


### PR DESCRIPTION
This allows specifying a custom event to start the `pointerAction` drag. I needed to start dragging only if the user holds the draggable node for some time. I used a custom `longpress` action to do so.

The custom event has to have the prop `startDragPosition` into its `details` containing `x` and `y` coordinates for the initial position. The update is quite simple, but I didn't log errors nor write tests. I'd like to know what you think first.

If this is something we wish to have in the lib (I obviously think we should), I can also implement some `customEndEvent`.

You have to pass the event and inject the event into the draggable nodes with a custom action:
```svelte
<div
  use:dndzone="{{
    items,
    customStartEvent: 'longpress',
  }}"
  on:consider
  on:finalize
>
  <span use:longpress>
    CONTENT
  </span>
</div>
```


