### PR TITLE
362 - fix: if a dropzone is destroyed during drag, it is kept in the DOM (hidden) until a drop takes place to prevent mid drag errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.17",
+    "version": "0.9.18",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,8 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.18](https://github.com/isaacHagoel/svelte-dnd-action/pull/365)
+fix: if a drop zone is removed mid-drag it was causing the lib to throw errors
+
 ### [0.9.17](https://github.com/isaacHagoel/svelte-dnd-action/pull/320)
 
 fix: dropdowns (select elements) will now maintain their value during drag

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -136,7 +136,7 @@ export function styleDraggable(draggableEl, dragDisabled) {
  * Hides the provided element so that it can stay in the dom without interrupting
  * @param {HTMLElement} dragTarget
  */
-export function hideOriginalDragTarget(dragTarget) {
+export function hideElement(dragTarget) {
     dragTarget.style.display = "none";
     dragTarget.style.position = "fixed";
     dragTarget.style.zIndex = "-5";


### PR DESCRIPTION
fixes #362 