### PR TITLE
Expose the dragged-over index in the DRAGGED_OVER_INDEX event

### DIFF
--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -207,7 +207,7 @@ function handleDraggedIsOverIndex(e) {
     const shadowElIdx = findShadowElementIdx(items);
     items.splice(shadowElIdx, 1);
     items.splice(index, 0, shadowElData);
-    dispatchConsiderEvent(e.currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER});
+    dispatchConsiderEvent(e.currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER, index});
 }
 
 // Global mouse/touch-events handlers


### PR DESCRIPTION
Currently, the DRAGGED_OVER_INDEX event doesn't actually expose the index of the item which the dragged-item was dragged over. That behavior is strange because the dragged-over index is pretty important when looking at the DRAGGED_OVER_INDEX event.