### PR TITLE
Fix scroller logic

### DIFF
--- a/src/helpers/scroller.js
+++ b/src/helpers/scroller.js
@@ -46,8 +46,10 @@ export function makeScroller() {
                 scrollingInfo.directionObj = {x: 0, y: -1};
                 scrollingInfo.stepPx = calcScrollStepPx(distances.top);
             }
-            if (!isAlreadyScrolling && scrollingVertically) {
-                scrollContainer(elementToScroll);
+            if (scrollingVertically) {
+                if (!isAlreadyScrolling) {
+                    scrollContainer(elementToScroll);
+                }
                 return true;
             }
         }
@@ -62,8 +64,10 @@ export function makeScroller() {
                 scrollingInfo.directionObj = {x: -1, y: 0};
                 scrollingInfo.stepPx = calcScrollStepPx(distances.left);
             }
-            if (!isAlreadyScrolling && scrollingHorizontally) {
-                scrollContainer(elementToScroll);
+            if (scrollingHorizontally) {
+                if (!isAlreadyScrolling) {
+                    scrollContainer(elementToScroll);
+                }
                 return true;
             }
         }


### PR DESCRIPTION
The original logic checks if the element is currently scrolling, if so, it will not begin another scroll. However, because it is missing a return, not only will it not begin another scroll, it will also proceed to the end of the function where it will call `resetScrolling()`. This terminates the ongoing scroll. So even though the element needs scrolling, no scrolling will be done at all.

This change adds the missing return.