### PR TITLE
Fix wrong id type in DndEventInfo

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,7 +66,7 @@ export enum SOURCES {
 
 export interface DndEventInfo {
     trigger: TRIGGERS; // the type of dnd event that took place
-    id: string;
+    id: number;
     source: SOURCES; // the type of interaction that the user used to perform the dnd operation
 }
 


### PR DESCRIPTION
When logging `e.detail.info` it shows that `id` is a number, just like in the items list. However, the typings show `DndEventInfo.id` to be a string, which is incorrect. 