### PR TITLE
454 - copying height and width from the computed styles when morphing…

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.22",
+    "version": "0.9.23",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,7 @@
 ## Svelte Dnd Action - Release Notes
+### [0.9.23](https://github.com/isaacHagoel/svelte-dnd-action/pull/457)
+
+Fix morphing when within css grid
 
 ### [0.9.22](https://github.com/isaacHagoel/svelte-dnd-action/pull/410)
 

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -77,6 +77,7 @@ export function morphDraggedElementToBeLike(draggedEl, copyFromEl, currentMouseX
             left: (currentMouseX - draggedElRect.left) / draggedElRect.width,
             top: (currentMouseY - draggedElRect.top) / draggedElRect.height
         };
+        // The lines below are commented out because of issue 454 - seems like these rect values take time to update when in grid layout, therefore this gets copied from the computed styles now
         // draggedEl.style.height = `${newRect.height}px`;
         // draggedEl.style.width = `${newRect.width}px`;
         draggedEl.style.left = `${parseFloat(draggedEl.style.left) - relativeDistanceOfMousePointerFromDraggedSides.left * widthChange}px`;

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -40,8 +40,8 @@ export function createDraggedElementFrom(originalElement, positionCenterOnXY) {
     draggedEl.style.margin = "0";
     // we can't have relative or automatic height and width or it will break the illusion
     draggedEl.style.boxSizing = "border-box";
-    // draggedEl.style.height = `${rect.height}px`;
-    // draggedEl.style.width = `${rect.width}px`;
+    draggedEl.style.height = `${rect.height}px`;
+    draggedEl.style.width = `${rect.width}px`;
     draggedEl.style.transition = `${trs("top")}, ${trs("left")}, ${trs("background-color")}, ${trs("opacity")}, ${trs("color")} `;
     // this is a workaround for a strange browser bug that causes the right border to disappear when all the transitions are added at the same time
     window.setTimeout(() => (draggedEl.style.transition += `, ${trs("width")}, ${trs("height")}`), 0);
@@ -77,8 +77,8 @@ export function morphDraggedElementToBeLike(draggedEl, copyFromEl, currentMouseX
             left: (currentMouseX - draggedElRect.left) / draggedElRect.width,
             top: (currentMouseY - draggedElRect.top) / draggedElRect.height
         };
-        draggedEl.style.height = `${newRect.height}px`;
-        draggedEl.style.width = `${newRect.width}px`;
+        // draggedEl.style.height = `${newRect.height}px`;
+        // draggedEl.style.width = `${newRect.width}px`;
         draggedEl.style.left = `${parseFloat(draggedEl.style.left) - relativeDistanceOfMousePointerFromDraggedSides.left * widthChange}px`;
         draggedEl.style.top = `${parseFloat(draggedEl.style.top) - relativeDistanceOfMousePointerFromDraggedSides.top * heightChange}px`;
     }
@@ -105,6 +105,7 @@ function copyStylesFromTo(copyFromEl, copyToEl) {
                 s === "opacity" ||
                 s === "color" ||
                 s === "list-style-type" ||
+                // copying with and height to make up for rect update timing issues in some browsers
                 s === "width" ||
                 s === "height"
         )

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -40,8 +40,8 @@ export function createDraggedElementFrom(originalElement, positionCenterOnXY) {
     draggedEl.style.margin = "0";
     // we can't have relative or automatic height and width or it will break the illusion
     draggedEl.style.boxSizing = "border-box";
-    draggedEl.style.height = `${rect.height}px`;
-    draggedEl.style.width = `${rect.width}px`;
+    // draggedEl.style.height = `${rect.height}px`;
+    // draggedEl.style.width = `${rect.width}px`;
     draggedEl.style.transition = `${trs("top")}, ${trs("left")}, ${trs("background-color")}, ${trs("opacity")}, ${trs("color")} `;
     // this is a workaround for a strange browser bug that causes the right border to disappear when all the transitions are added at the same time
     window.setTimeout(() => (draggedEl.style.transition += `, ${trs("width")}, ${trs("height")}`), 0);
@@ -104,7 +104,9 @@ function copyStylesFromTo(copyFromEl, copyToEl) {
                 s.startsWith("border") ||
                 s === "opacity" ||
                 s === "color" ||
-                s === "list-style-type"
+                s === "list-style-type" ||
+                s === "width" ||
+                s === "height"
         )
         .forEach(s => copyToEl.style.setProperty(s, computedStyle.getPropertyValue(s), computedStyle.getPropertyPriority(s)));
 }


### PR DESCRIPTION
copying height and width from the computed styles when morphing instead of using the rect because of a browser bug that causes wrong info on rect when inside css grid
fixes #454 