### PR TITLE
Change observer zone list to be updatable and update it on new zone while dragging

### DIFF
--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -33,7 +33,7 @@ let INSTRUCTION_IDs;
 
 /* drop-zones registration management */
 function registerDropZone(dropZoneEl, type) {
-    printDebug(() => "registering drop-zone if absent");
+    printDebug(() => "registering drop-zone if absent in keyboard dnd");
     if (typeToDropZones.size === 0) {
         printDebug(() => "adding global keydown and click handlers");
         INSTRUCTION_IDs = initAria();


### PR DESCRIPTION
Hey, this is linked to Issue #479 
as far as I can see I have implemented a solution. My solution udates the observe method everytime a dropzone is registered, the zone has the correct type and `isWorkingOnPreviousDrag` is true. One thing a am confused about: Why is the current dropzone registered on every considering of a drag in the zone (that is the case without my changes too)? That leads to lots of updates on the observer zone list and event listeners on the currently active zone will be registered multiple times.

Furthermore I don't know if there's a problem with pushing the [registration](https://github.com/m4nnke/svelte-dnd-action/blob/b85f00dcb45f018c0e00122f7a06667a9b3feee8/src/pointerAction.js#L525C15-L525C15) method down a few lines in `configure`, is that a problem? I need the finished config (specificly the `dropAnimationDurationMs`) to update the `currentObservationIntervalMs`.
 
And I think `dropZonesFromDeepToShallow` in [observer ](https://github.com/m4nnke/svelte-dnd-action/blob/b85f00dcb45f018c0e00122f7a06667a9b3feee8/src/helpers/observer.js#L18)doesn't necessarily need to be global in this implementation. I think it could just be declared as before without being `const`.

I was confused why there were multiple registrations from keyboardAction and pointerAction, to be more meaningfull, I changed the debug output to show, where the registration came from.

I hope that helps.

Might be a bug I encounterd: In the test REPL I sent in #479: If you drag an element and close the drop zone the dragged element is from by hovering over title, then letting go of the element, there will be an error the next time you open the drop zone.