### PR TITLE
Rewatch dragged element on zone registration while dragging

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.26",
+    "version": "0.9.27",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.27](https://github.com/isaacHagoel/svelte-dnd-action/pull/481)
+
+Fixing a problem that occurs when a drop zone is being created mid-drag. It is now possible to use this new drop zone in the same drag it was created in.
+
 ### [0.9.26](https://github.com/isaacHagoel/svelte-dnd-action/pull/476)
 
 Readme typo fix in an example: setFeatueFlag -> setFeatureFlag

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -73,6 +73,10 @@ function registerDropZone(dropZoneEl, type) {
     if (!typeToDropZones.get(type).has(dropZoneEl)) {
         typeToDropZones.get(type).add(dropZoneEl);
         incrementActiveDropZoneCount();
+        if (isWorkingOnPreviousDrag) {
+            unWatchDraggedElement();
+            watchDraggedElement();
+        }
     }
 }
 function unregisterDropZone(dropZoneEl, type) {
@@ -458,7 +462,6 @@ export function dndzone(node, options) {
             unregisterDropZone(node, config.type);
         }
         config.type = newType;
-        registerDropZone(node, newType);
         config.items = [...items];
         config.dragDisabled = dragDisabled;
         config.morphDisabled = morphDisabled;
@@ -509,6 +512,7 @@ export function dndzone(node, options) {
         config.dropFromOthersDisabled = dropFromOthersDisabled;
 
         dzToConfig.set(node, config);
+        registerDropZone(node, newType);
         const shadowElIdx = findShadowElementIdx(config.items);
         for (let idx = 0; idx < node.children.length; idx++) {
             const draggableEl = node.children[idx];


### PR DESCRIPTION
Hey, this is linked to Issue #479 (second try)

This solution seems to be working fine.

When rewatching the dragged element the config of the new zone has to be read, so the `registerDropZone` method has to fire after the config added to the config map.