### PR TITLE
483 - a working implementation of disallowing zones nested in shadow …

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -1,6 +1,6 @@
 import {dndzone as pointerDndZone} from "./pointerAction";
 import {dndzone as keyboardDndZone} from "./keyboardAction";
-import {ITEM_ID_KEY} from "./constants";
+import {ITEM_ID_KEY, SHADOW_ELEMENT_HINT_ATTRIBUTE_NAME} from "./constants";
 import {toString} from "./helpers/util";
 
 /**
@@ -25,6 +25,13 @@ import {toString} from "./helpers/util";
  * @return {{update: function, destroy: function}}
  */
 export function dndzone(node, options) {
+    if (shouldIgnoreZone(node)) {
+        console.error("IGNORING", node);
+        return {
+            update: (newOptions) => {console.warn("IGNORED UPDATE", newOptions)},
+            destroy: () => {console.warn("IGNORED DESTROY")}
+        };
+    }
     validateOptions(options);
     const pointerZone = pointerDndZone(node, options);
     const keyboardZone = keyboardDndZone(node, options);
@@ -35,10 +42,21 @@ export function dndzone(node, options) {
             keyboardZone.update(newOptions);
         },
         destroy: () => {
+            console.error("DESTROY", node, options);
             pointerZone.destroy();
             keyboardZone.destroy();
         }
     };
+}
+
+/**
+ * If the user marked something in the ancestry of our node as shadow element, we can ignore it
+ * We need the user to mark it for us because svelte updates the action from deep to shallow (but renders top down)
+ * @param {HTMLElement} node
+ * @return {boolean}
+ */
+function shouldIgnoreZone(node) {
+    return !!node.closest(`[${SHADOW_ELEMENT_HINT_ATTRIBUTE_NAME}="true"]`);
 }
 
 function validateOptions(options) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,7 +19,8 @@ export const SOURCES = {
 };
 
 export const SHADOW_ITEM_MARKER_PROPERTY_NAME = "isDndShadowItem";
-export const SHADOW_ELEMENT_ATTRIBUTE_NAME = "data-is-dnd-shadow-item";
+export const SHADOW_ELEMENT_ATTRIBUTE_NAME = "data-is-dnd-shadow-item-internal";
+export const SHADOW_ELEMENT_HINT_ATTRIBUTE_NAME = "data-is-dnd-shadow-item-hint";
 export const SHADOW_PLACEHOLDER_ITEM_ID = "id:dnd-shadow-placeholder-0000";
 export const DRAGGED_ELEMENT_ID = "dnd-action-dragged-el";
 

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -257,22 +257,25 @@ function handleDrop() {
                 id: draggedElData[ITEM_ID_KEY],
                 source: SOURCES.POINTER
         });
-        unlockOriginDzMinDimensions();
-        dispatchFinalizeEvent(shadowElDropZone, items, {
-            trigger: isDraggedOutsideOfAnyDz ? TRIGGERS.DROPPED_OUTSIDE_OF_ANY : TRIGGERS.DROPPED_INTO_ZONE,
-            id: draggedElData[ITEM_ID_KEY],
-            source: SOURCES.POINTER
-        });
-        if (shadowElDropZone !== originDropZone) {
-            // letting the origin drop zone know the element was permanently taken away
-            dispatchFinalizeEvent(originDropZone, dzToConfig.get(originDropZone).items, {
-                trigger: TRIGGERS.DROPPED_INTO_ANOTHER,
+        // We want to make sure the placeholder indeed trigger a re-render
+        window.requestAnimationFrame(() => {
+            unlockOriginDzMinDimensions();
+            dispatchFinalizeEvent(shadowElDropZone, items, {
+                trigger: isDraggedOutsideOfAnyDz ? TRIGGERS.DROPPED_OUTSIDE_OF_ANY : TRIGGERS.DROPPED_INTO_ZONE,
                 id: draggedElData[ITEM_ID_KEY],
                 source: SOURCES.POINTER
             });
-        }
-        unDecorateShadowElement(shadowElDropZone.children[shadowElIdx]);
-        cleanupPostDrop();
+            if (shadowElDropZone !== originDropZone) {
+                // letting the origin drop zone know the element was permanently taken away
+                dispatchFinalizeEvent(originDropZone, dzToConfig.get(originDropZone).items, {
+                    trigger: TRIGGERS.DROPPED_INTO_ANOTHER,
+                    id: draggedElData[ITEM_ID_KEY],
+                    source: SOURCES.POINTER
+                });
+            }
+            unDecorateShadowElement(shadowElDropZone.children[shadowElIdx]);
+            cleanupPostDrop();
+        });
     }
     animateDraggedToFinalPosition(shadowElIdx, finalizeWithinZone);
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -78,6 +78,7 @@ export type DndEvent<T = Item> = {
 export declare const SHADOW_ITEM_MARKER_PROPERTY_NAME: "isDndShadowItem";
 export declare const SHADOW_PLACEHOLDER_ITEM_ID: "id:dnd-shadow-placeholder-0000";
 export declare const DRAGGED_ELEMENT_ID: "dnd-action-dragged-el";
+export declare const SHADOW_ELEMENT_HINT_ATTRIBUTE_NAME = "data-is-dnd-shadow-item-hint";
 
 /**
  * Allows the user to show/hide console debug output


### PR DESCRIPTION
a working implementation of disallowing zones nested in shadow elements to init and destroying hidden elements right away. requires a hint from the user (marking the shadow parent) otherwise it's backwards compatible. 
Example (notice data-is-dnd-shadow-item-hint):
```html
 <div use:dndzone={{items: itemList, dropFromOthersDisabled: isDraggingInnerElement}} on:consider={handleConsider} on:finalize={handleFinalize}>
        {#each itemList as item (item.id)}
            <div style="background-color: green; padding: 10px; margin: 2px" data-is-dnd-shadow-item-hint={item[SHADOW_ITEM_MARKER_PROPERTY_NAME]}>
                <h1>{item.title}</h1>
                <InnerComponent innerItems={item.innerItems} id={item.id} disable={isDraggingOutterItem} on:draggingInnerElement={() => {isDraggingInnerElement = true}} on:innerChange={(event) => handleInnerChange(event)}/>
            </div>
        {/each}
    </div>
```


Still needs cleanup.
Also needs to test more and update the README.

fixes #483 