### PR TITLE
update for svelte 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,13 +269,12 @@ declare namespace svelte.JSX {
 #### Svelte 4:
 
 ```typescript
-declare type Item = import("svelte-dnd-action").Item;
-declare type DndEvent<ItemType = Item> = import("svelte-dnd-action").DndEvent<ItemType>;
-declare namespace svelteHTML {
-    interface HTMLAttributes<T> {
-        "on:consider"?: (event: CustomEvent<DndEvent<ItemType>> & {target: EventTarget & T}) => void;
-        "on:finalize"?: (event: CustomEvent<DndEvent<ItemType>> & {target: EventTarget & T}) => void;
-    }
+import type { DndEvent } from 'svelte-dnd-action';
+declare module 'svelte/elements' {
+	interface HTMLAttributes<T> {
+		'on:consider'?: EventHandler<CustomEvent<DndEvent<ItemType>>, T>;
+		'on:finalize'?: EventHandler<CustomEvent<DndEvent<ItemType>>, T>;
+	}
 }
 ```
 


### PR DESCRIPTION
From 4.2, we can declare 'svelte/elements' for custom attributes.
I use this and this is so good!

https://svelte.jp/docs/typescript#enhancing-built-in-dom-types