### PR TITLE
fix: add import and require exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
     "svelte": "src/index.js",
     "exports": {
         ".": {
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
             "svelte": "./src/index.js"
         }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.35",
+    "version": "0.9.36",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "svelte": "src/index.js",
     "exports": {
         ".": {
-			"import": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.mjs"
-			},
-			"require": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			},
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.mjs"
+            },
+            "require": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
             "svelte": "./src/index.js"
         }
     },

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.36](https://github.com/isaacHagoel/svelte-dnd-action/pull/528)
+
+Added `import` and `require` to the export block in package.json so that types are properly resolved.
+
 ### [0.9.35](https://github.com/isaacHagoel/svelte-dnd-action/pull/527)
 
 Added an export block to package.json to remove a Svelte 5 (actually vite) warning about the deprecated "svelte" entry


### PR DESCRIPTION
The package types were not able to be resolved with the new `exports` field being added. This PR fixes that by defining the `import` and `require` properties in `exports`.

References:
- https://nodejs.org/api/packages.html#package-entry-points
- https://nodejs.org/api/packages.html#conditional-exports

Side note: I'm not sure why the `svelte` property is targeting `src/index.js` rather than `dist/index.js`. I tested using `dist` locally and my SvelteKit project compiled and ran without issues.