### PR TITLE
docs: update README to help sveltekit + TS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ You may need to edit `tsconfig.json` to include `global.d.ts` if it doesn't alre
 >   kit: {
 >     typescript: {
 >       config(config) {
->         config.include.push('global.d.ts');
+>          // This path is relative to the ".svelte-kit" folder
+>         config.include.push('../global.d.ts');
 >       },
 >     },
 >   },

--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ declare namespace svelteHTML {
 ```
 
 You may need to edit `tsconfig.json` to include `global.d.ts` if it doesn't already: "include": ["src/**/*", "global.d.ts"].
+
+> Note: If you are using Sveltekit you should use `svelte.config.js` to modify the generated `tsconfig.json` rather than adding the `include` element to the root `tsconfig.json`.  Adding `include` to the root file will cause issues because it will [override](https://www.typescriptlang.org/tsconfig#extends) the `include` array defined in `.svelte-kit/tsconfig.json`. Example:
+> ```javascript
+> const config = {
+>   kit: {
+>     typescript: {
+>       config(config) {
+>         config.include.push('global.d.ts');
+>       },
+>     },
+>   },
+> };
+> ```
+
 Then you will be able to use the library with type safety as follows (Typescript gurus out there, improvements are welcome :smile:):
 
 ```html

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.38",
+    "version": "0.9.39",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.39](https://github.com/isaacHagoel/svelte-dnd-action/pull/538)
+
+Updated README to help set up sveltekit + typescript
+
 ### [0.9.38](https://github.com/isaacHagoel/svelte-dnd-action/pull/533)
 
 Added fault tolerance for use cases in which the user removes the shadow item from the list (e.g zones with limited slots)


### PR DESCRIPTION
Hi there! I'm using this library with SvelteKit and ran into some issues after I followed the instructions in the README to set up types for the events. The language server started complaining that it could not find type declarations for things like `./$types` or `$lib/....`. It turns out that the Typescript does not allow "extending" of the `include` key and adding an `include` element at the root `tsconfig.json` resulted in the ts compiler not knowing about the types that sveltekit declares. Thankfully this is easily solved by using sveltekit's function to modify the generated config rather than editing the root config. 

I just threw this in the readme for now, but happy to move it to where ever you feel is more appropriate. 