### PR TITLE
Allow add non-draggable element in dropzone container

### DIFF
--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -195,10 +195,10 @@ export function dndzone(node, options) {
                 e.preventDefault(); // prevent scrolling
                 e.stopPropagation();
                 const {items} = dzToConfig.get(node);
-                const children = Array.from(node.children);
+                const children = Array.from(node.children).slice(0, items.length);  // slice to prevent swap out of items range
                 const idx = children.indexOf(e.currentTarget);
                 printDebug(() => ["arrow down", idx]);
-                if (idx < children.length - 1) {
+                if (idx < items.length - 1) {
                     if (!config.autoAriaDisabled) {
                         alertToScreenReader(`Moved item ${focusedItemLabel} to position ${idx + 2} in the list ${focusedDzLabel}`);
                     }
@@ -213,7 +213,7 @@ export function dndzone(node, options) {
                 e.preventDefault(); // prevent scrolling
                 e.stopPropagation();
                 const {items} = dzToConfig.get(node);
-                const children = Array.from(node.children);
+                const children = Array.from(node.children).slice(0, items.length);  // slice to prevent swap out of items range
                 const idx = children.indexOf(e.currentTarget);
                 printDebug(() => ["arrow up", idx]);
                 if (idx > 0) {
@@ -312,7 +312,7 @@ export function dndzone(node, options) {
 
         node.addEventListener("focus", handleZoneFocus);
 
-        for (let i = 0; i < node.children.length; i++) {
+        for (let i = 0; i < config.items.length; i++) {
             const draggableEl = node.children[i];
             allDragTargets.add(draggableEl);
             draggableEl.tabIndex = isDragging ? -1 : config.zoneItemTabIndex;

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -511,7 +511,7 @@ export function dndzone(node, options) {
         dzToConfig.set(node, config);
         registerDropZone(node, newType);
         const shadowElIdx = findShadowElementIdx(config.items);
-        for (let idx = 0; idx < node.children.length; idx++) {
+        for (let idx = 0; idx < config.items.length; idx++) {
             const draggableEl = node.children[idx];
             styleDraggable(draggableEl, dragDisabled);
             if (idx === shadowElIdx) {


### PR DESCRIPTION
Change how dndzone children are being iterated to allow non-draggable element into drozone container AFTER item array. Fix #452. 

This will be possible afterwards: 
```html
<section use:dndzone>
  {#each itemsas item(item.id)}
    <div animate:flip>
      <!-- draggable -->	     
    </div>
  {/each}
  <span data-dnd-exclude>NON DRAGGABLE</span>
</section>
```

As of this comment:

> It sounds like a can of worms of edge-cases and complexity but I am open to ideas. i am happy to look at more detailed requirements or a PR if you can provide.

_Originally posted by @isaacHagoel in https://github.com/isaacHagoel/svelte-dnd-action/issues/452#issuecomment-1734542796_

All tests passed and also all example REPLs I _tried_ continue to works.

--- 
There is similar PR (based on name) #335 for this topic, but I would say, my PR is easier to reason about 😊 