### PR TITLE
fix: prevent drag from scrolling the page on safari

### DIFF
--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -384,6 +384,7 @@ export function dndzone(node, options) {
             printDebug(() => "cannot start a new drag before finalizing previous one");
             return;
         }
+        e.preventDefault();
         e.stopPropagation();
         const c = e.touches ? e.touches[0] : e;
         dragStartMousePosition = {x: c.clientX, y: c.clientY};


### PR DESCRIPTION
This library currently has an issue on touch devices (at least iOS safari), where trying to drag and drop will attempt to scroll the page. I ran into this with my own project, as well as any of the example REPLs.

I was able to fix it on my own project by adding a single `e.preventDefault()` in the right spot.

Figured I might as well PR this. I don't think this should affect anything other than fixing the scrolling issue, but let me know if it does.