### PR TITLE
Allow svelte ^5.0.0-next.0 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.43",
+    "version": "0.9.44",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "rollup-plugin-copy": "^3.3.0"
     },
     "peerDependencies": {
-        "svelte": ">=3.23.0"
+        "svelte": ">=3.23.0 || ^5.0.0-next.0"
     },
     "keywords": [
         "svelte",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.44](https://github.com/isaacHagoel/svelte-dnd-action/pull/567)
+
+Allows Svelte 5.0.0-next as peer dependency.
+
 ### [0.9.43](https://github.com/isaacHagoel/svelte-dnd-action/pull/556)
 
 Fixes an issue on some touch devices, where attempting to drag an item causes the page to scroll.


### PR DESCRIPTION
When using svelte 5.0.0-next, svelte-dnd-action causes a peer dependency issue. Since svelte-dnd-action appears to be compatible with svelte 5, it would be helpful to allow svelte 5.0.0-next as peer dependency.