### PR TITLE
597 - not looking for the shadow element if not working on previous drag to prevent error when dragging in another tab and syncing considers to the current tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.49",
+    "version": "0.9.50",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.50](https://github.com/isaacHagoel/svelte-dnd-action/pull/598)
+
+Fixed a bug where library would crash when a store updated "considers" in local storage from another tab
+
 ### [0.9.49](https://github.com/isaacHagoel/svelte-dnd-action/pull/588)
 
 Fixed a bug where library would crash if one of the canvas had an empty size

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -526,7 +526,7 @@ export function dndzone(node, options) {
 
         dzToConfig.set(node, config);
         registerDropZone(node, newType);
-        const shadowElIdx = findShadowElementIdx(config.items);
+        const shadowElIdx = isWorkingOnPreviousDrag ? findShadowElementIdx(config.items) : -1;
         for (let idx = 0; idx < node.children.length; idx++) {
             const draggableEl = node.children[idx];
             styleDraggable(draggableEl, dragDisabled);


### PR DESCRIPTION
fixes #597 