### PR TITLE
multiScroller undefined on destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.52",
+    "version": "0.9.53",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.53](https://github.com/isaacHagoel/svelte-dnd-action/pull/618)
+
+Added a check to address edge cases where multiScroller is undefined when accessed on destroy
+
 ### [0.9.52](https://github.com/isaacHagoel/svelte-dnd-action/pull/610)
 
 Fixed a bug that affected dndzone inside scrollable parents - calculated the target index incorrectly when the element was above a hidden part of the zone

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -113,8 +113,10 @@ function unWatchDraggedElement() {
         dz.removeEventListener(DRAGGED_OVER_INDEX_EVENT_NAME, handleDraggedIsOverIndex);
     }
     window.removeEventListener(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, handleDrop);
-    multiScroller.destroy();
-    multiScroller = undefined;
+    if(multiScroller) {
+        multiScroller.destroy();
+        multiScroller = undefined;
+    }
     unobserve();
 }
 

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -113,6 +113,7 @@ function unWatchDraggedElement() {
         dz.removeEventListener(DRAGGED_OVER_INDEX_EVENT_NAME, handleDraggedIsOverIndex);
     }
     window.removeEventListener(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, handleDrop);
+    // ensuring multiScroller is not already destroyed before destroying
     if(multiScroller) {
         multiScroller.destroy();
         multiScroller = undefined;


### PR DESCRIPTION
# multiScroller undefined on destroy

When rapidly moving items around within a single list, there were cases `multiScroller` was undefined when accessed (`destroy()` called) and caused an unhandled exception that left the `dndzone` in an unusable state until refresh. 

The solution I found was to wrap `multiScroller` in a truthy if block before attempting to destroy and set undefined. The check could be made safer by also ensuring `destroy` is a function on the `multiScroller` object, but that's probably overkill for this case.