### PR TITLE
FIX: infinite scroll on drag end

### DIFF
--- a/src/helpers/scroller.js
+++ b/src/helpers/scroller.js
@@ -1,4 +1,5 @@
 import {isPointInsideRect} from "./intersection";
+import { DRAGGED_ELEMENT_ID} from "../constants";
 const SCROLL_ZONE_PX = 30;
 
 /**
@@ -14,7 +15,8 @@ export function makeScroller() {
     // directionObj {x: 0|1|-1, y:0|1|-1} - 1 means down in y and right in x
     function scrollContainer(containerEl) {
         const {directionObj, stepPx} = scrollingInfo;
-        if (directionObj) {
+        const activeDragEl = document.querySelector(`#${DRAGGED_ELEMENT_ID}`);
+        if (directionObj && activeDragEl) {
             containerEl.scrollBy(directionObj.x * stepPx, directionObj.y * stepPx);
             window.requestAnimationFrame(() => scrollContainer(containerEl));
         }


### PR DESCRIPTION
Problem:
Releasing a drag element in a container WHILE it is scrolling will cause an infinite scroll in the direction that the container was scrolling.

Cause:
request animation frame keeps firing when releasing a drag item in a drop container while the drop container is actively scrolling

Solution:
Only call requestAnimationFrame in scroller.js if there is currently an active drag item.

Steps to reproduce:
-create a container for drop zone.
-create a container full of items.
-fill the drop zone container until there is an overflow.
-drag an item in the drop zone container and bring it towards the top or the bottom,  notice that the drop zone container will scroll up or down.
-release the item in the drop zone WHILE the scroll is happening.
-observe that the drop zone container scroll is stuck in the direction it was scrolling.