### PR TITLE
635 - separated the adding of the dragged element to the dom from keeping the original to prevent morph from running before it's in the DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.57",
+    "version": "0.9.58",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.58](https://github.com/isaacHagoel/svelte-dnd-action/pull/636)
+
+Bugfix: when the items in the origin zone shrink in height right on drag start, the pointer would find itself outside the dragged element
+
 ### [0.9.57](https://github.com/isaacHagoel/svelte-dnd-action/pull/629)
 
 Readme update (`on` vs `on:` handlers in Svelte 5)

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -434,16 +434,15 @@ export function dndzone(node, options) {
         // creating the draggable element
         draggedEl = createDraggedElementFrom(originalDragTarget, centreDraggedOnCursor && currentMousePosition);
         originalDragTarget.setAttribute(ORIGINAL_DRAGGED_ITEM_MARKER_ATTRIBUTE, true);
-
+        originDropZoneRoot.appendChild(draggedEl);
+        // to prevent the outline from disappearing
+        draggedEl.focus();
+        watchDraggedElement();
         // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
         function keepOriginalElementInDom() {
-            if (!draggedEl.parentElement) {
-                originDropZoneRoot.appendChild(draggedEl);
-                // to prevent the outline from disappearing
-                draggedEl.focus();
-                watchDraggedElement();
-                hideElement(originalDragTarget);
+            if (!originalDragTarget.parentElement) {
                 originDropZoneRoot.appendChild(originalDragTarget);
+                hideElement(originalDragTarget);
                 // after the removal of the original element we can give the shadow element the original item id so that the host zone can find it and render it correctly if it does lookups by id
                 shadowElData[ITEM_ID_KEY] = draggedElData[ITEM_ID_KEY];
             } else {

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -433,18 +433,18 @@ export function dndzone(node, options) {
 
         // creating the draggable element
         draggedEl = createDraggedElementFrom(originalDragTarget, centreDraggedOnCursor && currentMousePosition);
-        originalDragTarget.setAttribute(ORIGINAL_DRAGGED_ITEM_MARKER_ATTRIBUTE, true);
         originDropZoneRoot.appendChild(draggedEl);
-        // to prevent the outline from disappearing
-        draggedEl.focus();
-        watchDraggedElement();
         // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
         function keepOriginalElementInDom() {
             if (!originalDragTarget.parentElement) {
+                originalDragTarget.setAttribute(ORIGINAL_DRAGGED_ITEM_MARKER_ATTRIBUTE, true);
                 originDropZoneRoot.appendChild(originalDragTarget);
                 hideElement(originalDragTarget);
                 // after the removal of the original element we can give the shadow element the original item id so that the host zone can find it and render it correctly if it does lookups by id
                 shadowElData[ITEM_ID_KEY] = draggedElData[ITEM_ID_KEY];
+                // to prevent the outline from disappearing
+                draggedEl.focus();
+                watchDraggedElement();
             } else {
                 window.requestAnimationFrame(keepOriginalElementInDom);
             }


### PR DESCRIPTION
fixes #635 