### PR TITLE
Fix dragHandle bug: Reset isItemsDragDisabled on click without drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.60",
+    "version": "0.9.61",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.61](https://github.com/isaacHagoel/svelte-dnd-action/pull/645)
+
+Bugfix: Fixed an issue in `dragHandle` where clicking and releasing without dragging left `isItemsDragDisabled` as `false`, making the entire element draggable.
+
 ### [0.9.60](https://github.com/isaacHagoel/svelte-dnd-action/pull/639)
 
 Bugfix: the touchend listener was emulating a click using the click() function and that broke when the user clicked on an SVG

--- a/src/wrappers/withDragHandles.js
+++ b/src/wrappers/withDragHandles.js
@@ -85,19 +85,19 @@ export function dragHandle(handle) {
         e.preventDefault();
         isItemsDragDisabled.set(false);
 
-        // Reset isItemsDragDisabled if the user releases the mouse/touch without initiating a drag
-        const onEnd = () => {
-            isItemsDragDisabled.set(true);
-            window.removeEventListener("mouseup", onEnd);
-            window.removeEventListener("touchend", onEnd);
-        };
-
-        window.addEventListener("mouseup", onEnd);
-        window.addEventListener("touchend", onEnd);
+        // Reset the startDrag/isItemsDragDisabled if the user releases the mouse/touch without initiating a drag
+        window.addEventListener("mouseup", resetStartDrag);
+        window.addEventListener("touchend", resetStartDrag);
     }
 
     function handleKeyDown(e) {
         if (e.key === "Enter" || e.key === " ") isItemsDragDisabled.set(false);
+    }
+
+    function resetStartDrag() {
+        isItemsDragDisabled.set(true);
+        window.removeEventListener("mouseup", resetStartDrag);
+        window.removeEventListener("touchend", resetStartDrag);
     }
 
     isItemsDragDisabled.subscribe(disabled => {

--- a/src/wrappers/withDragHandles.js
+++ b/src/wrappers/withDragHandles.js
@@ -84,7 +84,18 @@ export function dragHandle(handle) {
         // preventing default to prevent lag on touch devices (because of the browser checking for screen scrolling)
         e.preventDefault();
         isItemsDragDisabled.set(false);
+
+        // Reset isItemsDragDisabled if the user releases the mouse/touch without initiating a drag
+        const onEnd = () => {
+            isItemsDragDisabled.set(true);
+            window.removeEventListener("mouseup", onEnd);
+            window.removeEventListener("touchend", onEnd);
+        };
+
+        window.addEventListener("mouseup", onEnd);
+        window.addEventListener("touchend", onEnd);
     }
+
     function handleKeyDown(e) {
         if (e.key === "Enter" || e.key === " ") isItemsDragDisabled.set(false);
     }


### PR DESCRIPTION
**Problem**: When clicking and releasing the drag handle without dragging, `isItemsDragDisabled` remains `false`, causing the entire element (and all others) to become draggable instead of only by the handle. I believe this is an unintended side effect that degrades the drag handle functionality.

**Solution**: Added `mouseup` and `touchend` event listeners in `dragHandle` to reset `isItemsDragDisabled` to `true` if no drag is initiated. The listeners are cleaned up properly.

**Testing**: I have tested this fix in a Svelte 5 project with both mouse and touch inputs, and it resolves the issue without introducing new problems. However, I have not conducted exhaustive testing across all use cases. Please let me know if you'd prefer this to be reported as an issue first or if further testing is needed.