### PR TITLE
Remove aria-disabled

### DIFF
--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -292,7 +292,6 @@ export function dndzone(node, options) {
         config.type = newType;
         registerDropZone(node, newType);
         if (!autoAriaDisabled) {
-            node.setAttribute("aria-disabled", dragDisabled);
             node.setAttribute("role", "list");
             node.setAttribute("aria-describedby", dragDisabled ? INSTRUCTION_IDs.DND_ZONE_DRAG_DISABLED : INSTRUCTION_IDs.DND_ZONE_ACTIVE);
         }


### PR DESCRIPTION
`aria-disabled` applies to all children components if used on a container.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled

> Note: The state of being disabled applies to the element with aria-disabled="true" and all of its focusable descendants. Take care when using this attribute on container elements. Particularly in the case where a container may have both form controls and links - where the intent may be to expose the form controls as being in the disabled state, but not to communicate the links as being "disabled".

Given that a drop zone is pretty much always associated with a container, I think setting `aria-disabled` is doing more harm than good -- if the container contains any focusable elements (common), they are also considered to be disabled.  Besides accessibility, this also effects integration tests that check if an element is enabled before performing an action on it (e.g., frameworks using playwright which recently began enforcing this for descendants https://github.com/microsoft/playwright/issues/35689).
