### PR TITLE
fix: stop keepOriginalElementInDom rAF loop once the drag is finalized

### DIFF
--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -511,6 +511,11 @@ export function dndzone(node, options) {
         originDropZoneRoot.appendChild(draggedEl);
         // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
         function keepOriginalElementInDom() {
+            // if the drag was already finalized (cleanupPostDrop cleared draggedEl), this rAF loop
+            // must not re-arm the watcher: the original element might leave the DOM long after the
+            // drop (ex: its component unmounts), which would call watchDraggedElement() with an
+            // undefined draggedEl and crash inside observe() (getBoundingClientRect of undefined)
+            if (!draggedEl) return;
             if (!originalDragTarget.parentElement) {
                 originalDragTarget.setAttribute(ORIGINAL_DRAGGED_ITEM_MARKER_ATTRIBUTE, true);
                 originDropZoneRoot.appendChild(originalDragTarget);


### PR DESCRIPTION
Fixes #684 — full root-cause analysis there.

One-line guard: `keepOriginalElementInDom()` is a self re-arming rAF loop that waits for the framework to remove the original dragged node, but it is never cancelled. If the drop wins that race (common with keyed `{#each}` blocks that reuse the node, so `parentElement` never becomes null during the drag), the loop stays alive as a zombie after `cleanupPostDrop()` cleared `draggedEl`. When the node finally leaves the DOM — possibly long after the drop, e.g. when its component unmounts — the loop takes the first branch and calls `watchDraggedElement()` with `draggedEl === undefined`, crashing inside `observe()`:

```
TypeError: undefined is not an object (evaluating 'e.getBoundingClientRect')
    at getAbsoluteRect (dist/index.mjs:420)
    at findCenterOfElement (dist/index.mjs:473)
    at andNow (dist/index.mjs:799)
```

The guard bails out of the loop once the drag is finalized. We have been running exactly this change in production (school iPads, Svelte 5, heavy touch dragging) via patch-package and the crash is gone with no observable side effects on normal drag behavior.