### PR TITLE
chore: prepare release 0.9.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.69",
+    "version": "0.9.70",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.70](https://github.com/isaacHagoel/svelte-dnd-action/pull/685)
+
+Bugfix: stop the `keepOriginalElementInDom` animation-frame loop after a drag is finalized, preventing a delayed crash when the original element leaves the DOM.
+
 ### [0.9.69](https://github.com/isaacHagoel/svelte-dnd-action/pull/679)
 
 Feature: Added `useCursorForDetection` option.


### PR DESCRIPTION
## Summary
- bump the package version to `0.9.70`
- add release notes for the finalized-drag rAF loop fix from #685

## Validation
- `git diff --check`
- `npx prettier --check package.json release-notes.md`