### PR TITLE
fix: prevent observer rearm during drop finalization

### DIFF
--- a/cypress/integration/pointerAction.spec.js
+++ b/cypress/integration/pointerAction.spec.js
@@ -1,0 +1,48 @@
+import {dndzone} from "../../src/pointerAction";
+
+describe("pointerAction", () => {
+    it("does not restart observation when the original element is removed while a drop is finalizing", () => {
+        let action;
+        let zone;
+        let originalRequestAnimationFrame;
+
+        cy.clock();
+        cy.then(() => {
+            const animationFrameCallbacks = [];
+            originalRequestAnimationFrame = window.requestAnimationFrame;
+            window.requestAnimationFrame = callback => {
+                animationFrameCallbacks.push(callback);
+                return animationFrameCallbacks.length;
+            };
+
+            zone = document.createElement("div");
+            zone.style.width = "100px";
+            zone.style.height = "100px";
+            const item = document.createElement("div");
+            item.style.width = "50px";
+            item.style.height = "50px";
+            zone.appendChild(item);
+            document.body.appendChild(zone);
+
+            action = dndzone(zone, {items: [{id: 1}], flipDurationMs: 100});
+
+            item.dispatchEvent(new MouseEvent("mousedown", {button: 0, clientX: 5, clientY: 5, bubbles: true, cancelable: true}));
+            window.dispatchEvent(new MouseEvent("mousemove", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+            window.dispatchEvent(new MouseEvent("mouseup", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+
+            item.remove();
+            animationFrameCallbacks.shift()();
+
+            // The pending keepOriginalElementInDom frame must stop rather than re-append the item
+            // and restart observation during the asynchronous drop-settle window.
+            expect(item.parentElement).to.equal(null);
+        });
+
+        cy.tick(107);
+        cy.then(() => {
+            action.destroy();
+            zone.remove();
+            window.requestAnimationFrame = originalRequestAnimationFrame;
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.70",
+    "version": "0.9.71",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 ## Svelte Dnd Action - Release Notes
 
-### 0.9.71
+### [0.9.71](https://github.com/isaacHagoel/svelte-dnd-action/pull/688)
 
 Bugfix: prevent the original-element animation-frame loop from restarting pointer observation while a drop is finalizing, avoiding an uncaught `getBoundingClientRect` error on fast animated drops. Adds defensive observer cleanup for the same race. Fixes [#687](https://github.com/isaacHagoel/svelte-dnd-action/issues/687).
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### 0.9.71
+
+Bugfix: prevent the original-element animation-frame loop from restarting pointer observation while a drop is finalizing, avoiding an uncaught `getBoundingClientRect` error on fast animated drops. Adds defensive observer cleanup for the same race. Fixes [#687](https://github.com/isaacHagoel/svelte-dnd-action/issues/687).
+
 ### [0.9.70](https://github.com/isaacHagoel/svelte-dnd-action/pull/685)
 
 Bugfix: stop the `keepOriginalElementInDom` animation-frame loop after a drag is finalized, preventing a delayed crash when the original element leaves the DOM.

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -268,6 +268,9 @@ function handleDrop() {
 
     items = items.map(item => (item[SHADOW_ITEM_MARKER_PROPERTY_NAME] ? draggedElData : item));
     function finalizeWithinZone() {
+        // The original-element rAF loop may have re-armed observation during the settle animation.
+        // Cancel again before dispatching events that can update or destroy drop zones.
+        unWatchDraggedElement();
         unlockOriginDzMinDimensions();
         dispatchFinalizeEvent(shadowElDropZone, items, {
             trigger: isDraggedOutsideOfAnyDz ? TRIGGERS.DROPPED_OUTSIDE_OF_ANY : TRIGGERS.DROPPED_INTO_ZONE,
@@ -511,11 +514,10 @@ export function dndzone(node, options) {
         originDropZoneRoot.appendChild(draggedEl);
         // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
         function keepOriginalElementInDom() {
-            // if the drag was already finalized (cleanupPostDrop cleared draggedEl), this rAF loop
-            // must not re-arm the watcher: the original element might leave the DOM long after the
-            // drop (ex: its component unmounts), which would call watchDraggedElement() with an
-            // undefined draggedEl and crash inside observe() (getBoundingClientRect of undefined)
-            if (!draggedEl) return;
+            // Once the drop starts finalizing, handleDrop has stopped observation and this loop
+            // must not re-arm it during the settle animation. After cleanup, draggedEl is cleared
+            // as an additional guard against the original element leaving the DOM much later.
+            if (!draggedEl || finalizingPreviousDrag) return;
             if (!originalDragTarget.parentElement) {
                 originalDragTarget.setAttribute(ORIGINAL_DRAGGED_ITEM_MARKER_ATTRIBUTE, true);
                 originDropZoneRoot.appendChild(originalDragTarget);


### PR DESCRIPTION
## Summary

- stop keepOriginalElementInDom once pointer-drop finalization begins
- defensively unwatch again after the settle animation and before finalize handlers run
- add regression coverage for removing the original node during the animated-drop window
- bump the package patch version to 0.9.71 and update the release notes

Fixes #687.

## Verification

- yarn lint
- yarn build
- Cypress regression spec added, but Cypress 4.12.1 aborts at runner startup with SIGABRT on the local macOS 25.5 environment (both Electron and explicit Chrome), before any spec executes