### PR TITLE
fix: harden drag lifecycle teardown

### DIFF
--- a/cypress/integration/dragHandleZone.spec.js
+++ b/cypress/integration/dragHandleZone.spec.js
@@ -1,0 +1,16 @@
+import {overrideItemIdKeyNameBeforeInitialisingDndZones} from "../../src/constants";
+import {dragHandleZone} from "../../src/wrappers/withDragHandles";
+
+describe("dragHandleZone", () => {
+    it("destroys its wrapped dndzone", () => {
+        const zone = document.createElement("div");
+        zone.appendChild(document.createElement("div"));
+        document.body.appendChild(zone);
+
+        const action = dragHandleZone(zone, {items: [{id: 1}]});
+        action.destroy();
+
+        expect(() => overrideItemIdKeyNameBeforeInitialisingDndZones("id")).not.to.throw();
+        zone.remove();
+    });
+});

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -1,0 +1,26 @@
+import {dndzone} from "../../src/keyboardAction";
+import {TRIGGERS} from "../../src/constants";
+
+describe("keyboardAction", () => {
+    it("can synchronously destroy the focused zone from the drag-stopped handler", () => {
+        const zone = document.createElement("div");
+        const item = document.createElement("div");
+        zone.appendChild(item);
+        document.body.appendChild(zone);
+
+        const action = dndzone(zone, {items: [{id: 1}]});
+        let dragStoppedEvents = 0;
+        zone.addEventListener("consider", e => {
+            if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) {
+                dragStoppedEvents++;
+                action.destroy();
+            }
+        });
+
+        item.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        item.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+        expect(dragStoppedEvents).to.equal(1);
+        zone.remove();
+    });
+});

--- a/cypress/integration/pointerAction.spec.js
+++ b/cypress/integration/pointerAction.spec.js
@@ -1,12 +1,177 @@
 import {dndzone} from "../../src/pointerAction";
+import {DRAGGED_ELEMENT_ID} from "../../src/constants";
+
+function createZone(options = {}) {
+    const zone = document.createElement("div");
+    zone.style.width = "100px";
+    zone.style.height = "100px";
+    const item = document.createElement("div");
+    item.style.width = "50px";
+    item.style.height = "50px";
+    item.textContent = options.label || "item";
+    zone.appendChild(item);
+    document.body.appendChild(zone);
+    const items = [{id: options.id || 1}];
+    const actionOptions = {...options, items};
+    delete actionOptions.id;
+    delete actionOptions.label;
+    const action = dndzone(zone, actionOptions);
+    return {action, actionOptions, item, items, zone};
+}
+
+function startMouseDrag(item) {
+    item.dispatchEvent(new MouseEvent("mousedown", {button: 0, clientX: 5, clientY: 5, bubbles: true, cancelable: true}));
+    window.dispatchEvent(new MouseEvent("mousemove", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+}
+
+function createTouchEvent(type, x = 5, y = 5) {
+    const event = new Event(type, {bubbles: true, cancelable: true});
+    Object.defineProperty(event, "touches", {value: type === "touchend" ? [] : [{clientX: x, clientY: y}]});
+    return event;
+}
+
+function stubTimeouts() {
+    const originalSetTimeout = window.setTimeout;
+    const originalClearTimeout = window.clearTimeout;
+    const pending = new Map();
+    let nextId = 1;
+    let now = 0;
+
+    window.setTimeout = (callback, delay = 0) => {
+        const id = nextId++;
+        pending.set(id, {callback, dueAt: now + delay});
+        return id;
+    };
+    window.clearTimeout = id => pending.delete(id);
+
+    return {
+        runAll: () => {
+            let remainingIterations = 100;
+            while (pending.size > 0 && remainingIterations-- > 0) {
+                const [id, timer] = Array.from(pending).sort(([, timerA], [, timerB]) => timerA.dueAt - timerB.dueAt)[0];
+                pending.delete(id);
+                now = timer.dueAt;
+                timer.callback();
+            }
+            if (pending.size > 0) throw new Error("timer queue did not settle");
+        },
+        restore: () => {
+            window.setTimeout = originalSetTimeout;
+            window.clearTimeout = originalClearTimeout;
+        }
+    };
+}
 
 describe("pointerAction", () => {
     it("does not restart observation when the original element is removed while a drop is finalizing", () => {
-        let action;
-        let zone;
+        cy.then(() => {
+            const timeouts = stubTimeouts();
+            const animationFrameCallbacks = [];
+            const originalRequestAnimationFrame = window.requestAnimationFrame;
+            window.requestAnimationFrame = callback => {
+                animationFrameCallbacks.push(callback);
+                return animationFrameCallbacks.length;
+            };
+
+            const created = createZone({flipDurationMs: 100});
+            startMouseDrag(created.item);
+            window.dispatchEvent(new MouseEvent("mouseup", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+
+            created.item.remove();
+            animationFrameCallbacks.shift()();
+
+            // The pending keepOriginalElementInDom frame must stop rather than re-append the item
+            // and restart observation during the asynchronous drop-settle window.
+            expect(created.item.parentElement).to.equal(null);
+
+            timeouts.runAll();
+            created.action.destroy();
+            created.zone.remove();
+            timeouts.restore();
+            window.requestAnimationFrame = originalRequestAnimationFrame;
+        });
+    });
+
+    it("unwatches the exact zones when their type changes during an active drag", () => {
+        cy.then(() => {
+            const timeouts = stubTimeouts();
+            const animationFrameCallbacks = [];
+            const originalRequestAnimationFrame = window.requestAnimationFrame;
+            window.requestAnimationFrame = callback => {
+                animationFrameCallbacks.push(callback);
+                return animationFrameCallbacks.length;
+            };
+
+            const created = createZone({dropAnimationDisabled: true, type: "before"});
+            startMouseDrag(created.item);
+            created.item.remove();
+            animationFrameCallbacks.shift()();
+            created.action.update({...created.actionOptions, type: "after"});
+            window.dispatchEvent(new MouseEvent("mouseup", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+
+            timeouts.runAll();
+            expect(document.getElementById(DRAGGED_ELEMENT_ID)).to.equal(null);
+            created.action.destroy();
+            created.zone.remove();
+            timeouts.restore();
+            window.requestAnimationFrame = originalRequestAnimationFrame;
+        });
+    });
+
+    it("finishes an animated drop when zones change type during the settle window", () => {
+        cy.then(() => {
+            const timeouts = stubTimeouts();
+            const created = createZone({flipDurationMs: 100, type: "before"});
+            startMouseDrag(created.item);
+            window.dispatchEvent(new MouseEvent("mouseup", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+            created.action.update({...created.actionOptions, type: "after"});
+
+            timeouts.runAll();
+            expect(document.getElementById(DRAGGED_ELEMENT_ID)).to.equal(null);
+            created.action.destroy();
+            created.zone.remove();
+            timeouts.restore();
+        });
+    });
+
+    it("cancels a delayed touch gesture when its zone is destroyed", () => {
+        cy.then(() => {
+            const timeouts = stubTimeouts();
+            const created = createZone({delayTouchStart: 50});
+            created.item.dispatchEvent(createTouchEvent("touchstart"));
+            created.action.destroy();
+            created.zone.remove();
+
+            timeouts.runAll();
+            expect(document.getElementById(DRAGGED_ELEMENT_ID)).to.equal(null);
+            timeouts.restore();
+        });
+    });
+
+    it("allows only one pending touch gesture to become a drag", () => {
+        cy.then(() => {
+            const timeouts = stubTimeouts();
+            const first = createZone({delayTouchStart: 50, dropAnimationDisabled: true, id: "first", label: "first"});
+            const second = createZone({delayTouchStart: 50, dropAnimationDisabled: true, id: "second", label: "second"});
+            first.item.dispatchEvent(createTouchEvent("touchstart"));
+            second.item.dispatchEvent(createTouchEvent("touchstart"));
+
+            timeouts.runAll();
+            const draggedElements = document.querySelectorAll(`#${DRAGGED_ELEMENT_ID}`);
+            expect(draggedElements).to.have.length(1);
+            expect(draggedElements[0].textContent).to.equal("first");
+            window.dispatchEvent(createTouchEvent("touchend"));
+            first.action.destroy();
+            second.action.destroy();
+            first.zone.remove();
+            second.zone.remove();
+            timeouts.restore();
+        });
+    });
+
+    it("does not reattach a zone after its scheduled removal was completed during drop cleanup", () => {
         let originalRequestAnimationFrame;
 
-        cy.clock();
         cy.then(() => {
             const animationFrameCallbacks = [];
             originalRequestAnimationFrame = window.requestAnimationFrame;
@@ -15,33 +180,13 @@ describe("pointerAction", () => {
                 return animationFrameCallbacks.length;
             };
 
-            zone = document.createElement("div");
-            zone.style.width = "100px";
-            zone.style.height = "100px";
-            const item = document.createElement("div");
-            item.style.width = "50px";
-            item.style.height = "50px";
-            zone.appendChild(item);
-            document.body.appendChild(zone);
-
-            action = dndzone(zone, {items: [{id: 1}], flipDurationMs: 100});
-
-            item.dispatchEvent(new MouseEvent("mousedown", {button: 0, clientX: 5, clientY: 5, bubbles: true, cancelable: true}));
-            window.dispatchEvent(new MouseEvent("mousemove", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+            const created = createZone({dropAnimationDisabled: true});
+            startMouseDrag(created.item);
+            created.action.destroy();
             window.dispatchEvent(new MouseEvent("mouseup", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
 
-            item.remove();
-            animationFrameCallbacks.shift()();
-
-            // The pending keepOriginalElementInDom frame must stop rather than re-append the item
-            // and restart observation during the asynchronous drop-settle window.
-            expect(item.parentElement).to.equal(null);
-        });
-
-        cy.tick(107);
-        cy.then(() => {
-            action.destroy();
-            zone.remove();
+            animationFrameCallbacks.forEach(callback => callback());
+            expect(created.zone.parentElement).to.equal(null);
             window.requestAnimationFrame = originalRequestAnimationFrame;
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.71",
+    "version": "0.9.72",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,15 @@
 ## Svelte Dnd Action - Release Notes
 
+### 0.9.72
+
+Bugfixes: harden drag lifecycle cleanup against timing-sensitive updates and teardown.
+
+-   Keep pointer observation tied to the exact zones being watched, including when zone types change during an animated drop.
+-   Cancel pending pointer and delayed-touch gestures when their owning zone is destroyed, and serialize simultaneous touch starts.
+-   Prevent stale animation frames from reattaching zones after drop cleanup has destroyed them.
+-   Make keyboard drop handling safe when event handlers synchronously destroy the focused zone.
+-   Destroy the wrapped dndzone when a `dragHandleZone` action is destroyed.
+
 ### [0.9.71](https://github.com/isaacHagoel/svelte-dnd-action/pull/688)
 
 Bugfix: prevent the original-element animation-frame loop from restarting pointer observation while a drop is finalizing, avoiding an uncaught `getBoundingClientRect` error on fast animated drops. Adds defensive observer cleanup for the same race. Fixes [#687](https://github.com/isaacHagoel/svelte-dnd-action/issues/687).

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 ## Svelte Dnd Action - Release Notes
 
-### 0.9.72
+### [0.9.72](https://github.com/isaacHagoel/svelte-dnd-action/pull/689)
 
 Bugfixes: harden drag lifecycle cleanup against timing-sensitive updates and teardown.
 

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -50,12 +50,13 @@ function registerDropZone(dropZoneEl, type) {
 }
 function unregisterDropZone(dropZoneEl, type) {
     printDebug(() => "unregistering drop-zone");
-    if (focusedDz === dropZoneEl) {
+    if (isDragging && focusedDz === dropZoneEl) {
         handleDrop();
     }
-    typeToDropZones.get(type).delete(dropZoneEl);
+    const dropZones = typeToDropZones.get(type);
+    if (!dropZones || !dropZones.delete(dropZoneEl)) return;
     decrementActiveDropZoneCount();
-    if (typeToDropZones.get(type).size === 0) {
+    if (dropZones.size === 0) {
         typeToDropZones.delete(type);
     }
     if (typeToDropZones.size === 0) {
@@ -112,9 +113,12 @@ function handleZoneFocus(e) {
         }
     }
     const dzFrom = focusedDz;
-    dispatchFinalizeEvent(dzFrom, originItems, {trigger: TRIGGERS.DROPPED_INTO_ANOTHER, id: focusedItemId, source: SOURCES.KEYBOARD});
-    dispatchFinalizeEvent(newlyFocusedDz, targetItems, {trigger: TRIGGERS.DROPPED_INTO_ZONE, id: focusedItemId, source: SOURCES.KEYBOARD});
+    const movedItemId = focusedItemId;
     focusedDz = newlyFocusedDz;
+    dispatchFinalizeEvent(dzFrom, originItems, {trigger: TRIGGERS.DROPPED_INTO_ANOTHER, id: movedItemId, source: SOURCES.KEYBOARD});
+    if (dzToConfig.has(newlyFocusedDz)) {
+        dispatchFinalizeEvent(newlyFocusedDz, targetItems, {trigger: TRIGGERS.DROPPED_INTO_ZONE, id: movedItemId, source: SOURCES.KEYBOARD});
+    }
 }
 
 function triggerAllDzsUpdate() {
@@ -122,25 +126,22 @@ function triggerAllDzsUpdate() {
 }
 
 function handleDrop(dispatchConsider = true) {
+    if (!isDragging || !focusedDz) return;
     printDebug(() => "drop");
-    if (!dzToConfig.get(focusedDz).autoAriaDisabled) {
+    const droppedDz = focusedDz;
+    const droppedConfig = dzToConfig.get(droppedDz);
+    const droppedItemId = focusedItemId;
+    const droppedItemType = draggedItemType;
+    if (!droppedConfig) return;
+
+    if (!droppedConfig.autoAriaDisabled) {
         alertToScreenReader(`Stopped dragging item ${focusedItemLabel}`);
     }
     if (allDragTargets.has(document.activeElement)) {
         document.activeElement.blur();
     }
-    if (dispatchConsider) {
-        dispatchConsiderEvent(focusedDz, dzToConfig.get(focusedDz).items, {
-            trigger: TRIGGERS.DRAG_STOPPED,
-            id: focusedItemId,
-            source: SOURCES.KEYBOARD
-        });
-    }
-    styleInactiveDropZones(
-        typeToDropZones.get(draggedItemType),
-        dz => dzToConfig.get(dz).dropTargetStyle,
-        dz => dzToConfig.get(dz).dropTargetClasses
-    );
+    // Clear global drag state before dispatching. A synchronous handler may destroy the
+    // focused zone, and unregisterDropZone must not recursively enter handleDrop.
     focusedItem = null;
     focusedItemId = null;
     focusedItemLabel = "";
@@ -148,10 +149,27 @@ function handleDrop(dispatchConsider = true) {
     focusedDz = null;
     focusedDzLabel = "";
     isDragging = false;
+
+    if (dispatchConsider) {
+        dispatchConsiderEvent(droppedDz, droppedConfig.items, {
+            trigger: TRIGGERS.DRAG_STOPPED,
+            id: droppedItemId,
+            source: SOURCES.KEYBOARD
+        });
+    }
+    const dropZones = typeToDropZones.get(droppedItemType);
+    if (dropZones) {
+        styleInactiveDropZones(
+            dropZones,
+            dz => dzToConfig.get(dz).dropTargetStyle,
+            dz => dzToConfig.get(dz).dropTargetClasses
+        );
+    }
     triggerAllDzsUpdate();
 }
 //////
 export function dndzone(node, options) {
+    let destroyed = false;
     const config = {
         items: undefined,
         type: undefined,
@@ -344,7 +362,14 @@ export function dndzone(node, options) {
             configure(newOptions);
         },
         destroy: () => {
+            if (destroyed) return;
+            destroyed = true;
             printDebug(() => "keyboard dndzone will destroy");
+            node.removeEventListener("focus", handleZoneFocus);
+            for (const draggableEl of node.children) {
+                draggableEl.removeEventListener("keydown", elToKeyDownListeners.get(draggableEl));
+                draggableEl.removeEventListener("click", elToFocusListeners.get(draggableEl));
+            }
             unregisterDropZone(node, config.type);
             dzToConfig.delete(node);
             dzToHandles.delete(node);

--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -64,6 +64,8 @@ let multiScroller;
 let touchDragHoldTimer;
 let touchHoldElapsed = false;
 let useCursorForDetectionActive = false;
+let pendingDragOwner;
+let watchedDropZones = new Set();
 
 // a map from type to a set of drop-zones
 const typeToDropZones = new Map();
@@ -84,9 +86,10 @@ function registerDropZone(dropZoneEl, type) {
     }
 }
 function unregisterDropZone(dropZoneEl, type) {
-    typeToDropZones.get(type).delete(dropZoneEl);
+    const dropZones = typeToDropZones.get(type);
+    if (!dropZones || !dropZones.delete(dropZoneEl)) return;
     decrementActiveDropZoneCount();
-    if (typeToDropZones.get(type).size === 0) {
+    if (dropZones.size === 0) {
         typeToDropZones.delete(type);
     }
 }
@@ -95,8 +98,11 @@ function unregisterDropZone(dropZoneEl, type) {
 function watchDraggedElement() {
     printDebug(() => "watching dragged element");
     const dropZones = typeToDropZones.get(draggedElType);
+    if (!dropZones || dropZones.size === 0) return;
+    if (watchedDropZones.size > 0) unWatchDraggedElement();
+    watchedDropZones = new Set(dropZones);
 
-    for (const dz of dropZones) {
+    for (const dz of watchedDropZones) {
         dz.addEventListener(DRAGGED_ENTERED_EVENT_NAME, handleDraggedEntered);
         dz.addEventListener(DRAGGED_LEFT_EVENT_NAME, handleDraggedLeft);
         dz.addEventListener(DRAGGED_OVER_INDEX_EVENT_NAME, handleDraggedIsOverIndex);
@@ -104,9 +110,9 @@ function watchDraggedElement() {
     window.addEventListener(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, handleDrop);
 
     // it is important that we don't have an interval that is faster than the flip duration because it can cause elements to jump bach and forth
-    const setIntervalMs = Math.max(...Array.from(dropZones.keys()).map(dz => dzToConfig.get(dz).dropAnimationDurationMs));
+    const setIntervalMs = Math.max(...Array.from(watchedDropZones).map(dz => dzToConfig.get(dz).dropAnimationDurationMs));
     const observationIntervalMs = setIntervalMs === 0 ? DISABLED_OBSERVATION_INTERVAL_MS : Math.max(setIntervalMs, MIN_OBSERVATION_INTERVAL_MS); // if setIntervalMs is 0 it goes to 20, otherwise it is max between it and min observation.
-    multiScroller = createMultiScroller(dropZones, () => currentMousePosition);
+    multiScroller = createMultiScroller(watchedDropZones, () => currentMousePosition);
     // Returns reference point in document coordinates - either cursor position or element center
     const getReferencePoint = useCursorForDetectionActive
         ? () => ({
@@ -114,16 +120,16 @@ function watchDraggedElement() {
               y: currentMousePosition.y + window.scrollY
           })
         : () => findCenterOfElement(draggedEl);
-    observe(draggedEl, dropZones, observationIntervalMs * 1.07, multiScroller, getReferencePoint);
+    observe(draggedEl, watchedDropZones, observationIntervalMs * 1.07, multiScroller, getReferencePoint);
 }
 function unWatchDraggedElement() {
     printDebug(() => "unwatching dragged element");
-    const dropZones = typeToDropZones.get(draggedElType);
-    for (const dz of dropZones) {
+    for (const dz of watchedDropZones) {
         dz.removeEventListener(DRAGGED_ENTERED_EVENT_NAME, handleDraggedEntered);
         dz.removeEventListener(DRAGGED_LEFT_EVENT_NAME, handleDraggedLeft);
         dz.removeEventListener(DRAGGED_OVER_INDEX_EVENT_NAME, handleDraggedIsOverIndex);
     }
+    watchedDropZones = new Set();
     window.removeEventListener(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, handleDrop);
     // ensuring multiScroller is not already destroyed before destroying
     if (multiScroller) {
@@ -315,8 +321,10 @@ function animateDraggedToFinalPosition(shadowElIdx, callback) {
 }
 
 function scheduleDZForRemovalAfterDrop(dz, destroy) {
-    scheduledForRemovalAfterDrop.push({dz, destroy});
+    const scheduledRemoval = {dz, destroy};
+    scheduledForRemovalAfterDrop.push(scheduledRemoval);
     window.requestAnimationFrame(() => {
+        if (!scheduledForRemovalAfterDrop.includes(scheduledRemoval)) return;
         hideElement(dz);
         document.body.appendChild(dz);
     });
@@ -351,6 +359,7 @@ function cleanupPostDrop() {
     touchDragHoldTimer = undefined;
     touchHoldElapsed = false;
     useCursorForDetectionActive = false;
+    pendingDragOwner = undefined;
     if (scheduledForRemovalAfterDrop.length) {
         printDebug(() => ["will destroy zones that were removed during drag", scheduledForRemovalAfterDrop]);
         scheduledForRemovalAfterDrop.forEach(({dz, destroy}) => {
@@ -363,6 +372,7 @@ function cleanupPostDrop() {
 
 export function dndzone(node, options) {
     let initialized = false;
+    let destroyed = false;
     const config = {
         items: undefined,
         type: undefined,
@@ -398,11 +408,17 @@ export function dndzone(node, options) {
             touchHoldElapsed = false;
         }
     }
-    function handleFalseAlarm(e) {
+    function cancelPendingDrag() {
+        if (pendingDragOwner !== node) return;
         removeMaybeListeners();
+        pendingDragOwner = undefined;
         originalDragTarget = undefined;
         dragStartMousePosition = undefined;
         currentMousePosition = undefined;
+    }
+    function handleFalseAlarm(e) {
+        if (pendingDragOwner !== node) return;
+        cancelPendingDrag();
 
         // dragging initiated by touch events prevents onclick from initially firing
         if (e.type === "touchend") {
@@ -416,6 +432,7 @@ export function dndzone(node, options) {
     }
 
     function handleMouseMoveMaybeDragStart(e) {
+        if (destroyed || pendingDragOwner !== node) return;
         const isTouch = !!e.touches;
         const c = isTouch ? e.touches[0] : e;
         // If touch drag delay is configured and not elapsed yet, allow scrolling until either
@@ -445,7 +462,6 @@ export function dndzone(node, options) {
             Math.abs(currentMousePosition.x - dragStartMousePosition.x) >= MIN_MOVEMENT_BEFORE_DRAG_START_PX ||
             Math.abs(currentMousePosition.y - dragStartMousePosition.y) >= MIN_MOVEMENT_BEFORE_DRAG_START_PX
         ) {
-            removeMaybeListeners();
             handleDragStart();
         }
     }
@@ -460,8 +476,8 @@ export function dndzone(node, options) {
             printDebug(() => `ignoring none left click button: ${e.button}`);
             return;
         }
-        if (isWorkingOnPreviousDrag) {
-            printDebug(() => "cannot start a new drag before finalizing previous one");
+        if (destroyed || isWorkingOnPreviousDrag || pendingDragOwner) {
+            printDebug(() => "cannot start a new drag before finalizing the current drag or pending gesture");
             return;
         }
         const isTouchStart = !!e.touches;
@@ -471,6 +487,7 @@ export function dndzone(node, options) {
             e.preventDefault();
         }
         e.stopPropagation();
+        pendingDragOwner = node;
 
         const c = isTouchStart ? e.touches[0] : e;
         dragStartMousePosition = {x: c.clientX, y: c.clientY};
@@ -478,12 +495,12 @@ export function dndzone(node, options) {
         originalDragTarget = e.currentTarget;
 
         if (useDelay) {
+            const pendingTarget = originalDragTarget;
             touchHoldElapsed = false;
             touchDragHoldTimer = window.setTimeout(() => {
-                // If the finger is still down and no false-alarm happened
-                if (!originalDragTarget) return;
+                // If this action still owns the same pending gesture, transition it to a drag.
+                if (destroyed || pendingDragOwner !== node || originalDragTarget !== pendingTarget) return;
                 touchHoldElapsed = true;
-                removeMaybeListeners();
                 handleDragStart();
             }, config.delayTouchStartMs);
         }
@@ -492,6 +509,12 @@ export function dndzone(node, options) {
     }
 
     function handleDragStart() {
+        if (destroyed || pendingDragOwner !== node || isWorkingOnPreviousDrag || !originalDragTarget?.parentElement) {
+            cancelPendingDrag();
+            return;
+        }
+        removeMaybeListeners();
+        pendingDragOwner = undefined;
         printDebug(() => [`drag start config: ${toString(config)}`, originalDragTarget]);
         isWorkingOnPreviousDrag = true;
 
@@ -670,9 +693,18 @@ export function dndzone(node, options) {
             configure(newOptions);
         },
         destroy: () => {
+            if (destroyed) return;
+            destroyed = true;
+            cancelPendingDrag();
+            for (const draggableEl of node.children) {
+                draggableEl.removeEventListener("mousedown", elToMouseDownListener.get(draggableEl));
+                draggableEl.removeEventListener("touchstart", elToMouseDownListener.get(draggableEl));
+            }
             function destroyDz() {
                 printDebug(() => "pointer dndzone will destroy");
-                unregisterDropZone(node, dzToConfig.get(node).type);
+                const registeredConfig = dzToConfig.get(node);
+                if (!registeredConfig) return;
+                unregisterDropZone(node, registeredConfig.type);
                 dzToConfig.delete(node);
             }
             if (isWorkingOnPreviousDrag && !node.closest(`[${ORIGINAL_DRAGGED_ITEM_MARKER_ATTRIBUTE}]`)) {

--- a/src/wrappers/withDragHandles.js
+++ b/src/wrappers/withDragHandles.js
@@ -77,6 +77,8 @@ export function dragHandleZone(node, options) {
             updateZone();
         },
         destroy: () => {
+            isItemsDragDisabled.set(true);
+            zone.destroy();
             node.removeEventListener("consider", consider);
             node.removeEventListener("finalize", finalize);
             isItemsDragDisabled.unsubscribe(updateZone);


### PR DESCRIPTION
## Summary

- tie pointer observation cleanup to the exact watched zones, even across type changes
- serialize pending pointer/touch gestures and cancel them when their zone is destroyed
- prevent stale removal frames from reattaching destroyed zones
- make keyboard drop teardown safe when handlers synchronously destroy the focused zone
- destroy the wrapped dndzone from dragHandleZone
- bump the package version to 0.9.72 and add release notes

## Verification

- `npm run test` (28 passing, 2 pre-existing pending)
- `yarn build`