### PR TITLE
fix: preserve cursor position during remorph

### DIFF
--- a/cypress/integration/styler.spec.js
+++ b/cypress/integration/styler.spec.js
@@ -1,0 +1,97 @@
+import {createDraggedElementFrom, morphDraggedElementToBeLike} from "../../src/helpers/styler";
+import {FEATURE_FLAG_NAMES, setFeatureFlag} from "../../src/featureFlags";
+
+function createElement(width, height) {
+    const element = document.createElement("div");
+    element.style.width = `${width}px`;
+    element.style.height = `${height}px`;
+    element.style.position = "fixed";
+    element.style.left = "0px";
+    element.style.top = "0px";
+    document.body.appendChild(element);
+    return element;
+}
+
+function stubRenderedRect(element, {left, top, width, height}) {
+    element.getBoundingClientRect = () => ({
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height
+    });
+}
+
+describe("styler", () => {
+    afterEach(() => {
+        setFeatureFlag(FEATURE_FLAG_NAMES.USE_COMPUTED_STYLE_INSTEAD_OF_BOUNDING_RECT, false);
+    });
+
+    [false, true].forEach(useComputedDimensions => {
+        it(`preserves the cursor position when remorphing during a transition (computed dimensions: ${useComputedDimensions})`, () => {
+            cy.then(() => {
+                setFeatureFlag(FEATURE_FLAG_NAMES.USE_COMPUTED_STYLE_INSTEAD_OF_BOUNDING_RECT, useComputedDimensions);
+                const draggedEl = createElement(200, 200);
+                const targetEl = createElement(100, 100);
+                const nativeGetComputedStyle = window.getComputedStyle.bind(window);
+                const getComputedStyleStub = cy.stub(window, "getComputedStyle").callsFake(element => {
+                    const computedStyle = nativeGetComputedStyle(element);
+                    if (element !== draggedEl) return computedStyle;
+                    return new Proxy(computedStyle, {
+                        get(target, property) {
+                            if (property === "left" || property === "top") return "25px";
+                            const value = target[property];
+                            return typeof value === "function" ? value.bind(target) : value;
+                        }
+                    });
+                });
+
+                try {
+                    // Model the midpoint of a previous morph. Its inline destination is
+                    // 0px, while the currently rendered/animated position is 25px.
+                    stubRenderedRect(draggedEl, {left: 25, top: 25, width: 150, height: 150});
+                    stubRenderedRect(targetEl, {left: 0, top: 0, width: 100, height: 100});
+
+                    morphDraggedElementToBeLike(draggedEl, targetEl, 100, 100);
+
+                    // The cursor is halfway across the rendered box, so a 100px target
+                    // must finish at 50px to keep the same relative grab point.
+                    expect(parseFloat(draggedEl.style.left)).to.equal(50);
+                    expect(parseFloat(draggedEl.style.top)).to.equal(50);
+                } finally {
+                    getComputedStyleStub.restore();
+                    draggedEl.remove();
+                    targetEl.remove();
+                }
+            });
+        });
+    });
+
+    it("synchronizes size transitions when morphing before delayed transition setup", () => {
+        cy.then(() => {
+            const originalEl = createElement(100, 100);
+            const targetEl = createElement(200, 200);
+            const nativeSetTimeout = window.setTimeout;
+            window.setTimeout = () => 1;
+            let draggedEl;
+
+            try {
+                draggedEl = createDraggedElementFrom(originalEl);
+                document.body.appendChild(draggedEl);
+                expect(draggedEl.style.transitionProperty.split(", ")).not.to.include("width");
+
+                morphDraggedElementToBeLike(draggedEl, targetEl, 50, 50);
+
+                const transitionProperties = draggedEl.style.transitionProperty.split(", ");
+                expect(transitionProperties).to.include("width");
+                expect(transitionProperties).to.include("height");
+            } finally {
+                window.setTimeout = nativeSetTimeout;
+                originalEl.remove();
+                targetEl.remove();
+                if (draggedEl) draggedEl.remove();
+            }
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.72",
+    "version": "0.9.73",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### 0.9.73
+
+Bugfix: preserve the cursor's relative grab point when a dragged element morphs again before its previous size transition completes. Size and position transitions are also synchronized when the first morph happens before delayed transition setup.
+
 ### [0.9.72](https://github.com/isaacHagoel/svelte-dnd-action/pull/689)
 
 Bugfixes: harden drag lifecycle cleanup against timing-sensitive updates and teardown.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 ## Svelte Dnd Action - Release Notes
 
-### 0.9.73
+### [0.9.73](https://github.com/isaacHagoel/svelte-dnd-action/pull/690)
 
 Bugfix: preserve the cursor's relative grab point when a dragged element morphs again before its previous size transition completes. Size and position transitions are also synchronized when the first morph happens before delayed transition setup.
 

--- a/src/helpers/styler.js
+++ b/src/helpers/styler.js
@@ -13,6 +13,19 @@ const TRANSITION_DURATION_SECONDS = 0.2;
 function trs(property) {
     return `${property} ${TRANSITION_DURATION_SECONDS}s ease`;
 }
+
+/**
+ * Adds the size transitions after the dragged element's initial styles have been applied.
+ * This normally happens in a timeout to avoid a browser rendering bug, but a synchronous
+ * first morph can happen before that timeout and needs the transitions immediately.
+ * @param {HTMLElement} draggedEl
+ */
+function ensureMorphSizeTransitions(draggedEl) {
+    const transitionProperties = draggedEl.style.transitionProperty.split(",").map(property => property.trim());
+    if (transitionProperties.includes("all")) return;
+    if (!transitionProperties.includes("width")) draggedEl.style.transition += `, ${trs("width")}`;
+    if (!transitionProperties.includes("height")) draggedEl.style.transition += `, ${trs("height")}`;
+}
 /**
  * clones the given element and applies proper styles and transitions to the dragged element
  * @param {HTMLElement} originalElement
@@ -45,7 +58,7 @@ export function createDraggedElementFrom(originalElement, positionCenterOnXY) {
     draggedEl.style.width = `${rect.width}px`;
     draggedEl.style.transition = `${trs("top")}, ${trs("left")}, ${trs("background-color")}, ${trs("opacity")}, ${trs("color")} `;
     // this is a workaround for a strange browser bug that causes the right border to disappear when all the transitions are added at the same time
-    window.setTimeout(() => (draggedEl.style.transition += `, ${trs("width")}, ${trs("height")}`), 0);
+    window.setTimeout(() => ensureMorphSizeTransitions(draggedEl), 0);
     draggedEl.style.zIndex = "9999";
     draggedEl.style.cursor = "grabbing";
 
@@ -68,22 +81,26 @@ export function moveDraggedElementToWasDroppedState(draggedEl) {
  * @param {number} currentMouseY
  */
 export function morphDraggedElementToBeLike(draggedEl, copyFromEl, currentMouseX, currentMouseY) {
+    ensureMorphSizeTransitions(draggedEl);
     copyStylesFromTo(copyFromEl, draggedEl);
     const newRect = copyFromEl.getBoundingClientRect();
     const draggedElRect = draggedEl.getBoundingClientRect();
+    const draggedElComputedStyle = window.getComputedStyle(draggedEl);
+    const currentLeft = parseFloat(draggedElComputedStyle.left);
+    const currentTop = parseFloat(draggedElComputedStyle.top);
     const widthChange = newRect.width - draggedElRect.width;
     const heightChange = newRect.height - draggedElRect.height;
     if (widthChange || heightChange) {
         const relativeDistanceOfMousePointerFromDraggedSides = {
-            left: (currentMouseX - draggedElRect.left) / draggedElRect.width,
-            top: (currentMouseY - draggedElRect.top) / draggedElRect.height
+            left: draggedElRect.width ? (currentMouseX - draggedElRect.left) / draggedElRect.width : 0,
+            top: draggedElRect.height ? (currentMouseY - draggedElRect.top) / draggedElRect.height : 0
         };
         if (!getFeatureFlag(FEATURE_FLAG_NAMES.USE_COMPUTED_STYLE_INSTEAD_OF_BOUNDING_RECT)) {
             draggedEl.style.height = `${newRect.height}px`;
             draggedEl.style.width = `${newRect.width}px`;
         }
-        draggedEl.style.left = `${parseFloat(draggedEl.style.left) - relativeDistanceOfMousePointerFromDraggedSides.left * widthChange}px`;
-        draggedEl.style.top = `${parseFloat(draggedEl.style.top) - relativeDistanceOfMousePointerFromDraggedSides.top * heightChange}px`;
+        draggedEl.style.left = `${currentLeft - relativeDistanceOfMousePointerFromDraggedSides.left * widthChange}px`;
+        draggedEl.style.top = `${currentTop - relativeDistanceOfMousePointerFromDraggedSides.top * heightChange}px`;
     }
 }
 


### PR DESCRIPTION
## Summary

- base morph positioning on the dragged element's current animated `left`/`top`, rather than the previous inline destination
- activate width and height transitions when an immediate first morph beats the delayed transition setup
- avoid invalid position calculations for zero-sized axes
- cover in-flight remorphs in both bounding-rect and computed-dimension modes
- bump the package version to 0.9.73 and add release notes

## Verification

- `npm run test` (31 passing, 2 pre-existing pending)
- `yarn build`