### PR TITLE
fix: prevent stale nested handle shadow

### DIFF
--- a/cypress/integration/dragHandleZone.spec.js
+++ b/cypress/integration/dragHandleZone.spec.js
@@ -1,5 +1,5 @@
-import {overrideItemIdKeyNameBeforeInitialisingDndZones} from "../../src/constants";
-import {dragHandleZone} from "../../src/wrappers/withDragHandles";
+import {overrideItemIdKeyNameBeforeInitialisingDndZones, SHADOW_ELEMENT_ATTRIBUTE_NAME, SHADOW_ITEM_MARKER_PROPERTY_NAME} from "../../src/constants";
+import {dragHandle, dragHandleZone} from "../../src/wrappers/withDragHandles";
 
 describe("dragHandleZone", () => {
     it("destroys its wrapped dndzone", () => {
@@ -12,5 +12,60 @@ describe("dragHandleZone", () => {
 
         expect(() => overrideItemIdKeyNameBeforeInitialisingDndZones("id")).not.to.throw();
         zone.remove();
+    });
+
+    it("does not apply a stale shadow index when a nested zone is destroyed during a drag", () => {
+        cy.then(() => {
+            const rootZone = document.createElement("div");
+            const draggedItem = document.createElement("div");
+            const dragHandleEl = document.createElement("div");
+            const nextItem = document.createElement("div");
+            const lastItem = document.createElement("div");
+            draggedItem.appendChild(dragHandleEl);
+            rootZone.appendChild(draggedItem);
+            rootZone.appendChild(nextItem);
+            rootZone.appendChild(lastItem);
+            document.body.appendChild(rootZone);
+
+            const nestedZone = document.createElement("div");
+            nestedZone.appendChild(document.createElement("div"));
+            document.body.appendChild(nestedZone);
+
+            const items = [{id: "dragged"}, {id: "next"}, {id: "last"}];
+            let shadowItems;
+            rootZone.addEventListener("consider", e => {
+                shadowItems = e.detail.items;
+            });
+
+            const rootAction = dragHandleZone(rootZone, {items, dropAnimationDisabled: true});
+            const handleAction = dragHandle(dragHandleEl);
+            const nestedAction = dragHandleZone(nestedZone, {items: [{id: "nested"}], dropAnimationDisabled: true});
+
+            try {
+                dragHandleEl.dispatchEvent(new MouseEvent("mousedown", {button: 0, clientX: 5, clientY: 5, bubbles: true, cancelable: true}));
+                window.dispatchEvent(new MouseEvent("mousemove", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+
+                expect(shadowItems.find(item => item[SHADOW_ITEM_MARKER_PROPERTY_NAME])).not.to.equal(undefined);
+
+                // Model Svelte having removed the shadow DOM node while the action wrapper
+                // still holds the previous options. Destroying an unrelated nested wrapper
+                // must not broadcast a stale update to the root zone.
+                const shadowItem = document.createElement("div");
+                rootZone.replaceChild(shadowItem, draggedItem);
+                rootAction.update({items: shadowItems, dropAnimationDisabled: true});
+                shadowItem.remove();
+                nestedAction.destroy();
+
+                expect(nextItem.hasAttribute(SHADOW_ELEMENT_ATTRIBUTE_NAME)).to.equal(false);
+                expect(nextItem.style.visibility).to.equal("");
+            } finally {
+                window.dispatchEvent(new MouseEvent("mouseup", {clientX: 10, clientY: 10, bubbles: true, cancelable: true}));
+                nestedAction.destroy();
+                rootAction.destroy();
+                handleAction.destroy();
+                rootZone.remove();
+                nestedZone.remove();
+            }
+        });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.73",
+    "version": "0.9.74",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### 0.9.74
+
+Bugfix: prevent nested `dragHandleZone` teardown during an active drag from broadcasting a stale update that can hide a real item as the shadow element.
+
 ### [0.9.73](https://github.com/isaacHagoel/svelte-dnd-action/pull/690)
 
 Bugfix: preserve the cursor's relative grab point when a dragged element morphs again before its previous size transition completes. Size and position transitions are also synchronized when the first morph happens before delayed transition setup.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 ## Svelte Dnd Action - Release Notes
 
-### 0.9.74
+### [0.9.74](https://github.com/isaacHagoel/svelte-dnd-action/pull/691)
 
 Bugfix: prevent nested `dragHandleZone` teardown during an active drag from broadcasting a stale update that can hide a real item as the shadow element.
 

--- a/src/wrappers/withDragHandles.js
+++ b/src/wrappers/withDragHandles.js
@@ -77,7 +77,6 @@ export function dragHandleZone(node, options) {
             updateZone();
         },
         destroy: () => {
-            isItemsDragDisabled.set(true);
             zone.destroy();
             node.removeEventListener("consider", consider);
             node.removeEventListener("finalize", finalize);


### PR DESCRIPTION
## Summary

- stop `dragHandleZone.destroy()` from broadcasting a global handle-state reset during nested Svelte teardown
- retain wrapped dndzone destruction from the lifecycle hardening change
- add a regression test that models stale action options after Svelte removes a nested shadow node
- bump the package version to 0.9.74 and add release notes

## Root cause

Destroying a nested handle zone notified every handle-zone subscriber while Svelte was between its DOM and action-option updates. A parent zone could then apply a stale shadow index to the first real child, leaving that item hidden with the internal shadow attribute.

## Verification

- `npm run test` (32 passing, 2 pre-existing pending)
- `yarn build`
- reproduced the reported `App.crazyNestingWithHandles.svelte` drag path; node2 and node3 remain visible and no real root item retains the shadow marker