### PR TITLE
fix(keyboard): keep the dragged item's zone in sync with the consumer

### DIFF
--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -23,4 +23,116 @@ describe("keyboardAction", () => {
         expect(dragStoppedEvents).to.equal(1);
         zone.remove();
     });
+
+    it("follows the grabbed item when a re-render moves it to another zone", () => {
+        const zoneA = document.createElement("div");
+        const itemA = document.createElement("div");
+        const itemB = document.createElement("div");
+        zoneA.appendChild(itemA);
+        zoneA.appendChild(itemB);
+        const zoneB = document.createElement("div");
+        document.body.appendChild(zoneA);
+        document.body.appendChild(zoneB);
+
+        const actionA = dndzone(zoneA, {items: [{id: "a"}, {id: "b"}]});
+        const actionB = dndzone(zoneB, {items: []});
+
+        const triggers = [];
+        const dragStoppedOn = [];
+        [zoneA, zoneB].forEach(zone =>
+            zone.addEventListener("consider", e => {
+                triggers.push(e.detail.info.trigger);
+                if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) dragStoppedOn.push(zone);
+            })
+        );
+
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+        // a consumer re-render lands mid-grab and moves the grabbed item to the other zone
+        zoneA.removeChild(itemA);
+        actionA.update({items: [{id: "b"}]});
+        zoneB.appendChild(itemA);
+        actionB.update({items: [{id: "a"}]});
+
+        expect(triggers.filter(t => t === TRIGGERS.DRAG_STOPPED).length, "should keep the drag alive").to.equal(0);
+        expect(document.activeElement, "should keep the item focused").to.equal(itemA);
+
+        // the grab now belongs to the other zone, so dropping it reports there
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        expect(dragStoppedOn, "should stop the drag in the zone that holds the item").to.deep.equal([zoneB]);
+
+        actionA.destroy();
+        actionB.destroy();
+        zoneA.remove();
+        zoneB.remove();
+    });
+
+    it("ends the grab when a re-render removes the grabbed item from every zone", () => {
+        const zoneA = document.createElement("div");
+        const itemA = document.createElement("div");
+        const itemB = document.createElement("div");
+        zoneA.appendChild(itemA);
+        zoneA.appendChild(itemB);
+        const zoneB = document.createElement("div");
+        document.body.appendChild(zoneA);
+        document.body.appendChild(zoneB);
+
+        const actionA = dndzone(zoneA, {items: [{id: "a"}, {id: "b"}], zoneTabIndex: 3});
+        const actionB = dndzone(zoneB, {items: []});
+        const triggers = [];
+        zoneA.addEventListener("consider", e => triggers.push(e.detail.info.trigger));
+
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+        // a consumer re-render lands mid-grab and drops the grabbed item
+        zoneA.removeChild(itemA);
+        actionA.update({items: [{id: "b"}], zoneTabIndex: 3});
+
+        // tab into the other zone
+        zoneB.dispatchEvent(new FocusEvent("focus"));
+
+        expect(triggers.filter(t => t === TRIGGERS.DRAG_STOPPED).length, "should stop the drag").to.equal(1);
+        expect(zoneA.tabIndex, "should restore the zone tab index").to.equal(3);
+        expect(itemB.tabIndex, "should restore the item tab index").to.equal(0);
+
+        actionA.destroy();
+        actionB.destroy();
+        zoneA.remove();
+        zoneB.remove();
+    });
+
+    it("does not move a different item when the grabbed item is missing from its origin zone", () => {
+        const zoneA = document.createElement("div");
+        const itemA = document.createElement("div");
+        const itemB = document.createElement("div");
+        zoneA.appendChild(itemA);
+        zoneA.appendChild(itemB);
+        const zoneB = document.createElement("div");
+        document.body.appendChild(zoneA);
+        document.body.appendChild(zoneB);
+
+        const actionA = dndzone(zoneA, {items: [{id: "a"}, {id: "b"}]});
+        const actionB = dndzone(zoneB, {items: []});
+
+        const finalizeOnA = [];
+        const finalizeOnB = [];
+        zoneA.addEventListener("finalize", e => finalizeOnA.push(e.detail));
+        zoneB.addEventListener("finalize", e => finalizeOnB.push(e.detail));
+
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+        // a consumer re-render lands mid-grab and drops the grabbed item
+        zoneA.removeChild(itemA);
+        actionA.update({items: [{id: "b"}]});
+
+        zoneB.dispatchEvent(new FocusEvent("focus"));
+
+        expect(finalizeOnB.length, "should not move an unrelated item into the target zone").to.equal(0);
+        expect(finalizeOnA.length, "should not remove an unrelated item from the origin zone").to.equal(0);
+
+        actionA.destroy();
+        actionB.destroy();
+        zoneA.remove();
+        zoneB.remove();
+    });
 });

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -86,11 +86,23 @@ function globalClickHandler() {
     }
 }
 
+// A consumer re-render can take the dragged item out of every zone mid-grab, leaving
+// focusedDz pointing at a zone that no longer holds it. There is nothing left to drag,
+// so drop rather than act on the stale pointer.
+function grabIsAlive() {
+    if (dzToConfig.get(focusedDz)?.items.some(item => item[ITEM_ID_KEY] === focusedItemId)) return true;
+    printDebug(() => "dragged item is gone, dropping");
+    handleDrop();
+    return false;
+}
+
 function handleZoneFocus(e) {
     printDebug(() => "zone focus");
     if (!isDragging) return;
     const newlyFocusedDz = e.currentTarget;
     if (newlyFocusedDz === focusedDz) return;
+
+    if (!grabIsAlive()) return;
 
     focusedDzLabel = newlyFocusedDz.getAttribute("aria-label") || "";
     const {items: originItems} = dzToConfig.get(focusedDz);
@@ -316,6 +328,11 @@ export function dndzone(node, options) {
         dzToConfig.set(node, config);
 
         if (isDragging) {
+            // the consumer may have moved the dragged item into this zone behind our back
+            if (config.items.some(item => item[ITEM_ID_KEY] === focusedItemId)) {
+                focusedDz = node;
+                focusedDzLabel = node.getAttribute("aria-label") || "";
+            }
             node.tabIndex =
                 node === focusedDz ||
                 focusedItem.contains(node) ||
@@ -344,7 +361,7 @@ export function dndzone(node, options) {
                 draggableEl.addEventListener("click", handleClick);
                 elToFocusListeners.set(draggableEl, handleClick);
             }
-            if (isDragging && config.items[i][ITEM_ID_KEY] === focusedItemId) {
+            if (isDragging && config.items[i]?.[ITEM_ID_KEY] === focusedItemId) {
                 printDebug(() => ["focusing on", {i, focusedItemId}]);
                 // if it is a nested dropzone, it was re-rendered and we need to refresh our pointer
                 focusedItem = draggableEl;


### PR DESCRIPTION
A consumer re-render can land mid-grab and take the dragged item out of the zone it is being dragged from (an external update, a filter, a live edit from another client - keyboard grabs stay open for as long as the user takes). focusedDz kept pointing at the old zone, so tabbing to another zone spliced at index -1 and moved the last item of the old zone instead, which also made the dragged item disappear.

configure() already re-points focusedItem when it finds the dragged item in a zone it is re-rendering, but it never re-pointed focusedDz along with it. It does now, so a grab follows its item when the consumer moves it to another zone, whichever of the two zones is re-rendered first.

When no zone holds the item there is nothing left to drag. Tabbing to another zone now drops instead of splicing from a zone that no longer has it; escape, clicking away and dropping already ended the grab, and the arrow keys can't be reached with the item's element gone.