### PR TITLE
fix: sync keyboard drag after consumer updates

### DIFF
--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -81,6 +81,39 @@ describe("keyboardAction", () => {
         });
     });
 
+    it("keeps a same-type nested zone untabbable when the moved item is recreated", () => {
+        const {
+            zone: zoneA,
+            action: actionA,
+            children: [itemA]
+        } = createZone([{id: "a"}, {id: "b"}]);
+        const {zone: zoneB, action: actionB} = createZone([]);
+
+        itemA.focus();
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+        zoneA.removeChild(itemA);
+        actionA.update({items: [{id: "b"}]});
+
+        const replacementItem = document.createElement("div");
+        const nestedZone = document.createElement("div");
+        nestedZone.appendChild(document.createElement("div"));
+        replacementItem.appendChild(nestedZone);
+        zoneB.appendChild(replacementItem);
+
+        // Svelte configures a nested action before the action on its parent.
+        const nestedAction = dndzone(nestedZone, {items: [{id: "nested"}]});
+        actions.push(nestedAction);
+        expect(nestedZone.tabIndex, "should initially reflect the old focused item").to.equal(0);
+
+        actionB.update({items: [{id: "a"}]});
+
+        expect(document.activeElement, "should focus the replacement item").to.equal(replacementItem);
+        expect(zoneA.tabIndex, "should make the old zone reachable").to.equal(0);
+        expect(zoneB.tabIndex, "should remove the new current zone from the tab order").to.equal(-1);
+        expect(nestedZone.tabIndex, "should keep a nested zone inside the dragged item unreachable").to.equal(-1);
+    });
+
     it("does not let another zone type with the same item id steal the grab", () => {
         const {
             zone: zoneA,

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -2,13 +2,33 @@ import {dndzone} from "../../src/keyboardAction";
 import {TRIGGERS} from "../../src/constants";
 
 describe("keyboardAction", () => {
-    it("can synchronously destroy the focused zone from the drag-stopped handler", () => {
-        const zone = document.createElement("div");
-        const item = document.createElement("div");
-        zone.appendChild(item);
-        document.body.appendChild(zone);
+    const actions = [];
+    const zones = [];
 
-        const action = dndzone(zone, {items: [{id: 1}]});
+    function createZone(items, options = {}) {
+        const zone = document.createElement("div");
+        items.forEach(() => zone.appendChild(document.createElement("div")));
+        document.body.appendChild(zone);
+        zones.push(zone);
+        const action = dndzone(zone, {items, ...options});
+        actions.push(action);
+        return {zone, action, children: Array.from(zone.children)};
+    }
+
+    afterEach(() => {
+        actions
+            .splice(0)
+            .reverse()
+            .forEach(action => action.destroy());
+        zones.splice(0).forEach(zone => zone.remove());
+    });
+
+    it("can synchronously destroy the focused zone from the drag-stopped handler", () => {
+        const {
+            zone,
+            action,
+            children: [item]
+        } = createZone([{id: 1}]);
         let dragStoppedEvents = 0;
         zone.addEventListener("consider", e => {
             if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) {
@@ -21,6 +41,111 @@ describe("keyboardAction", () => {
         item.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
 
         expect(dragStoppedEvents).to.equal(1);
-        zone.remove();
+    });
+
+    ["source first", "destination first"].forEach(updateOrder => {
+        it(`follows the grabbed item when a consumer moves it to another zone (${updateOrder})`, () => {
+            const {
+                zone: zoneA,
+                action: actionA,
+                children: [itemA]
+            } = createZone([{id: "a"}, {id: "b"}]);
+            const {zone: zoneB, action: actionB} = createZone([]);
+            const dragStoppedOn = [];
+            [zoneA, zoneB].forEach(zone =>
+                zone.addEventListener("consider", e => {
+                    if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) dragStoppedOn.push(zone);
+                })
+            );
+
+            itemA.focus();
+            itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+            zoneA.removeChild(itemA);
+            const movedItem = updateOrder === "source first" ? itemA : document.createElement("div");
+            zoneB.appendChild(movedItem);
+            if (updateOrder === "source first") {
+                actionA.update({items: [{id: "b"}]});
+                actionB.update({items: [{id: "a"}]});
+            } else {
+                actionB.update({items: [{id: "a"}]});
+                actionA.update({items: [{id: "b"}]});
+            }
+
+            expect(document.activeElement, "should keep the moved item focused").to.equal(movedItem);
+            expect(zoneA.tabIndex, "should make the previous zone reachable again").to.equal(0);
+            expect(zoneB.tabIndex, "should remove the current zone from the tab order").to.equal(-1);
+
+            movedItem.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+            expect(dragStoppedOn, "should stop the drag in the zone that now holds the item").to.deep.equal([zoneB]);
+        });
+    });
+
+    it("does not let another zone type with the same item id steal the grab", () => {
+        const {
+            zone: zoneA,
+            children: [itemA]
+        } = createZone([{id: "same"}], {type: "type-a"});
+        const {
+            zone: zoneB,
+            action: actionB,
+            children: [itemB]
+        } = createZone([{id: "same"}], {type: "type-b"});
+        const dragStoppedOn = [];
+        [zoneA, zoneB].forEach(zone =>
+            zone.addEventListener("consider", e => {
+                if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) dragStoppedOn.push(zone);
+            })
+        );
+
+        itemA.focus();
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        actionB.update({items: [{id: "same"}], type: "type-b"});
+
+        expect(document.activeElement, "should keep focus on the grabbed item").to.equal(itemA);
+        expect(itemB.tabIndex, "should not make the unrelated item active").to.equal(-1);
+
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        expect(dragStoppedOn, "should stop the drag in its original zone").to.deep.equal([zoneA]);
+    });
+
+    it("ends the grab when a consumer removes the grabbed item from every zone", () => {
+        const {
+            zone: zoneA,
+            action: actionA,
+            children: [itemA, itemB]
+        } = createZone([{id: "a"}, {id: "b"}], {zoneTabIndex: 3});
+        const {zone: zoneB} = createZone([]);
+        const triggers = [];
+        zoneA.addEventListener("consider", e => triggers.push(e.detail.info.trigger));
+
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        zoneA.removeChild(itemA);
+        actionA.update({items: [{id: "b"}], zoneTabIndex: 3});
+
+        zoneB.dispatchEvent(new FocusEvent("focus"));
+
+        expect(triggers.filter(trigger => trigger === TRIGGERS.DRAG_STOPPED)).to.have.length(1);
+        expect(zoneA.tabIndex, "should restore the configured zone tab index").to.equal(3);
+        expect(itemB.tabIndex, "should restore the item tab index").to.equal(0);
+    });
+
+    it("does not move another item when the grabbed item is missing", () => {
+        const {
+            zone: zoneA,
+            action: actionA,
+            children: [itemA]
+        } = createZone([{id: "a"}, {id: "b"}]);
+        const {zone: zoneB} = createZone([]);
+        const finalized = [];
+        [zoneA, zoneB].forEach(zone => zone.addEventListener("finalize", e => finalized.push(e.detail)));
+
+        itemA.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        zoneA.removeChild(itemA);
+        actionA.update({items: [{id: "b"}]});
+
+        zoneB.dispatchEvent(new FocusEvent("focus"));
+
+        expect(finalized, "should not finalize a move for an unrelated item").to.be.empty;
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.74",
+    "version": "0.9.75",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,13 @@
 ## Svelte Dnd Action - Release Notes
 
+### 0.9.75
+
+Bugfix: keep an active keyboard drag synchronized when a consumer re-render moves or removes the grabbed item.
+
+-   Follow an item moved between same-type zones without losing focus or cross-zone keyboard navigation.
+-   End the drag safely if the item disappears instead of moving an unrelated item from a stale origin.
+-   Keep zones of other types isolated even when they use the same item id.
+
 ### [0.9.74](https://github.com/isaacHagoel/svelte-dnd-action/pull/691)
 
 Bugfix: prevent nested `dragHandleZone` teardown during an active drag from broadcasting a stale update that can hide a real item as the shadow element.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 ## Svelte Dnd Action - Release Notes
 
-### 0.9.75
+### [0.9.75](https://github.com/isaacHagoel/svelte-dnd-action/pull/694)
 
 Bugfix: keep an active keyboard drag synchronized when a consumer re-render moves or removes the grabbed item.
 

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -86,11 +86,31 @@ function globalClickHandler() {
     }
 }
 
+function getActiveDragTabIndex(dropZoneEl, config) {
+    return dropZoneEl === focusedDz || focusedItem.contains(dropZoneEl) || config.dropFromOthersDisabled || config.type !== draggedItemType ? -1 : 0;
+}
+
+function refreshActiveDragTabIndices() {
+    dzToConfig.forEach((config, dropZoneEl) => {
+        dropZoneEl.tabIndex = getActiveDragTabIndex(dropZoneEl, config);
+    });
+}
+
+function grabIsAlive() {
+    const focusedConfig = dzToConfig.get(focusedDz);
+    if (focusedConfig?.items.some(item => item[ITEM_ID_KEY] === focusedItemId)) return true;
+    printDebug(() => "dragged item is gone, dropping");
+    handleDrop();
+    return false;
+}
+
 function handleZoneFocus(e) {
     printDebug(() => "zone focus");
     if (!isDragging) return;
     const newlyFocusedDz = e.currentTarget;
     if (newlyFocusedDz === focusedDz) return;
+
+    if (!grabIsAlive()) return;
 
     focusedDzLabel = newlyFocusedDz.getAttribute("aria-label") || "";
     const {items: originItems} = dzToConfig.get(focusedDz);
@@ -316,13 +336,15 @@ export function dndzone(node, options) {
         dzToConfig.set(node, config);
 
         if (isDragging) {
-            node.tabIndex =
-                node === focusedDz ||
-                focusedItem.contains(node) ||
-                config.dropFromOthersDisabled ||
-                (focusedDz && config.type !== dzToConfig.get(focusedDz).type)
-                    ? -1
-                    : 0;
+            const itemMovedToThisZone =
+                config.type === draggedItemType && config.items.some(item => item[ITEM_ID_KEY] === focusedItemId) && node !== focusedDz;
+            if (itemMovedToThisZone) {
+                focusedDz = node;
+                focusedDzLabel = node.getAttribute("aria-label") || "";
+                refreshActiveDragTabIndices();
+            } else {
+                node.tabIndex = getActiveDragTabIndex(node, config);
+            }
         } else {
             node.tabIndex = config.zoneTabIndex;
         }
@@ -344,7 +366,7 @@ export function dndzone(node, options) {
                 draggableEl.addEventListener("click", handleClick);
                 elToFocusListeners.set(draggableEl, handleClick);
             }
-            if (isDragging && config.items[i][ITEM_ID_KEY] === focusedItemId) {
+            if (isDragging && config.type === draggedItemType && config.items[i]?.[ITEM_ID_KEY] === focusedItemId) {
                 printDebug(() => ["focusing on", {i, focusedItemId}]);
                 // if it is a nested dropzone, it was re-rendered and we need to refresh our pointer
                 focusedItem = draggableEl;

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -335,16 +335,15 @@ export function dndzone(node, options) {
         }
         dzToConfig.set(node, config);
 
+        let itemMovedToThisZone = false;
         if (isDragging) {
-            const itemMovedToThisZone =
+            itemMovedToThisZone =
                 config.type === draggedItemType && config.items.some(item => item[ITEM_ID_KEY] === focusedItemId) && node !== focusedDz;
             if (itemMovedToThisZone) {
                 focusedDz = node;
                 focusedDzLabel = node.getAttribute("aria-label") || "";
-                refreshActiveDragTabIndices();
-            } else {
-                node.tabIndex = getActiveDragTabIndex(node, config);
             }
+            node.tabIndex = getActiveDragTabIndex(node, config);
         } else {
             node.tabIndex = config.zoneTabIndex;
         }
@@ -374,6 +373,11 @@ export function dndzone(node, options) {
                 // without this the element loses focus if it moves backwards in the list
                 draggableEl.focus();
             }
+        }
+        if (itemMovedToThisZone) {
+            // Nested actions are configured before their parent action. Refresh only
+            // after focusedItem points at the replacement so nested zones stay untabbable.
+            refreshActiveDragTabIndices();
         }
     }
     configure(options);


### PR DESCRIPTION
## Summary

- keep an active keyboard drag attached to an item when a consumer re-render moves it between same-type zones
- safely stop the drag when the item disappears instead of splicing the last unrelated origin item
- refresh cross-zone tab stops when drag ownership changes
- keep same-type nested zones inside a recreated dragged item out of the active tab order
- prevent zones of another type with the same item id from stealing focus or receiving the drop
- bump the package to 0.9.75 and add release notes

## Root cause

Keyboard drag state retained `focusedDz` after consumer-driven list updates. A subsequent zone focus could therefore search a stale origin, produce index `-1`, and move the wrong item. Simply adopting any zone that contains the id is also unsafe because ids are only required to be unique within a zone type, and changing the focused zone without refreshing tab indices can make the previous zone reachable incorrectly.

Because Svelte initializes nested actions before their parent action, the tab-index refresh must also happen after `focusedItem` points at the replacement element. Otherwise a same-type nested zone inside the dragged item can remain tabbable.

## Validation

- `npm test` — 40 passing
- `yarn build` — includes lint and package bundling
- rebuilt-package browser verification for source-first and destination-first moves, item removal, and duplicate ids across different types
- regression coverage for DOM reparenting and replacement, both consumer update orders, nested child-before-parent action setup, removal from every zone, and cross-type duplicate ids

Follow-up to #693.
