### PR TITLE
fix: name the drop zone in keyboard drag announcements

### DIFF
--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -181,4 +181,43 @@ describe("keyboardAction", () => {
 
         expect(finalized, "should not finalize a move for an unrelated item").to.be.empty;
     });
+
+    describe("announcements", () => {
+        function alertText() {
+            return document.getElementById("dnd-action-aria-alert").textContent;
+        }
+
+        function createLabelledZone(items, zoneLabel, options = {}) {
+            const {zone, action, children} = createZone(items, options);
+            zone.setAttribute("aria-label", zoneLabel);
+            children.forEach((child, i) => child.setAttribute("aria-label", `Card ${i}`));
+            return {zone, action, children};
+        }
+
+        function grab(item) {
+            item.focus();
+            item.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+        }
+
+        it("names the zone when the drag starts", () => {
+            const {
+                children: [item]
+            } = createLabelledZone([{id: "a"}, {id: "b"}], "To do");
+
+            grab(item);
+
+            expect(alertText()).to.equal("Started dragging item Card 0. Use the arrow keys to move it within its list To do");
+        });
+
+        it("names the zone when arrowing within the list", () => {
+            const {
+                children: [item]
+            } = createLabelledZone([{id: "a"}, {id: "b"}], "To do");
+
+            grab(item);
+            item.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown", bubbles: true, cancelable: true}));
+
+            expect(alertText()).to.equal("Moved item Card 0 to position 2 in the list To do");
+        });
+    });
 });

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -269,6 +269,7 @@ export function dndzone(node, options) {
         printDebug(() => "drag start");
         setCurrentFocusedItem(e.currentTarget);
         focusedDz = node;
+        focusedDzLabel = node.getAttribute("aria-label") || "";
         draggedItemType = config.type;
         isDragging = true;
         const dropTargets = Array.from(typeToDropZones.get(config.type)).filter(dz => dz === focusedDz || !dzToConfig.get(dz).dropFromOthersDisabled);


### PR DESCRIPTION
### The problem

`focusedDzLabel` is assigned in two places — `handleZoneFocus`, and `configure` when an item moves into a zone — and reset to `""` on drop. Nothing assigns it when a drag *starts*.

So on current `master`, every keyboard announcement omits the list name until the user tabs to a **different** zone:

```
"Started dragging item Card 0. Use the arrow keys to move it within its list "
"Moved item Card 0 to position 2 in the list "
```

### The fix

One line in `handleDragStart`, populating the label from the zone the drag started in, the same way `handleZoneFocus` already does:

```js
focusedDz = node;
focusedDzLabel = node.getAttribute("aria-label") || "";
```

### Tests

Two regression tests added to `cypress/integration/keyboardAction.spec.js`, using the unit-style harness from #694 — no fixture app, no timing. They assert the complete sentences rather than just the presence of the label, so they also pin the existing wording:

- `"Started dragging item Card 0. Use the arrow keys to move it within its list To do"`
- `"Moved item Card 0 to position 2 in the list To do"`

Both fail on `master` with the empty-label output shown above, and pass with the fix.

`yarn lint` clean, `yarn test` 42/42 passing.
