### PR TITLE
chore: prepare release 0.9.76

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.75",
+    "version": "0.9.76",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.76](https://github.com/isaacHagoel/svelte-dnd-action/pull/695)
+
+Bugfix: include the originating drop-zone label in keyboard drag announcements so screen-reader users hear the list name from drag start and while reordering within the list.
+
 ### [0.9.75](https://github.com/isaacHagoel/svelte-dnd-action/pull/694)
 
 Bugfix: keep an active keyboard drag synchronized when a consumer re-render moves or removes the grabbed item.


### PR DESCRIPTION
## Summary

- bump the package version to `0.9.76`
- document the keyboard drag announcement fix from #695 in the release notes

## Why

PR #695 fixes keyboard drag announcements so they include the originating drop-zone label. This follow-up prepares that merged fix for publication.

## Impact

Publishing `0.9.76` will make the accessibility fix available to consumers and record it in the project release notes.

## Validation

- `npm test` — 42 tests passing
- `yarn build` — lint and Rollup build passing
