### PR TITLE
Security: DOM-Based Cross-Site Scripting (XSS) via select option value

### DIFF
--- a/src/helpers/svelteNodeClone.js
+++ b/src/helpers/svelteNodeClone.js
@@ -22,7 +22,8 @@ export function svelteNodeClone(el) {
         for (let i = 0; i < clonedSelects.length; i++) {
             const select = clonedSelects[i];
             const value = values[i];
-            const optionEl = select.querySelector(`option[value="${value}"`);
+            const options = [...select.querySelectorAll("option")];
+            const optionEl = options.find((option) => option.value === value);
             if (optionEl) {
                 optionEl.setAttribute("selected", true);
             }


### PR DESCRIPTION
## Summary

Security: DOM-Based Cross-Site Scripting (XSS) via select option value

## Problem

**Severity**: `Medium` | **File**: `src/helpers/svelteNodeClone.js:L24`

In `svelteNodeClone.js`, the `value` of a `<select>` element is interpolated directly into a CSS selector string passed to `querySelector`. If an application uses option values that contain double quotes, spaces, or other CSS selector metacharacters, this can lead to a DOM exception or selector injection. In a worst-case scenario, if an attacker can control the select value (e.g., `value="a], [x=")`, they can break out of the intended selector and match arbitrary elements within the cloned node.

## Solution

Avoid interpolating untrusted values directly into CSS selectors. Instead, iterate through the cloned `<select>` element's `<option>` children and match their `value` property against the target value programmatically, or use `CSS.escape()` to safely escape the value before injecting it into the selector.

## Changes

- `src/helpers/svelteNodeClone.js` (modified)