### PR TITLE
feat(a11y): setAriaStrings for localizable screen-reader copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ setAriaStrings({
 });
 ```
 
-Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation; they receive `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` for the move messages and `canMoveBetweenZones` for `dragStarted`.
+Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation; `dragStarted`, `movedToPosition`, `movedToZoneEnd` and `movedToZoneStart` receive `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` for the move messages and `canMoveBetweenZones` for `dragStarted`; `dropped` receives only `itemLabel`.
 
-You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Pass `null` to go back to the built-in English. Passing an unrecognised key throws, so typos surface immediately.
+You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Pass `null` to go back to the built-in English. Passing an unrecognised key, or a value of the wrong type for its key, throws, so mistakes surface immediately. This is global and applies to all dndzones — you can't configure two zones with different aria strings.
 
 ##### Keyboard support
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ An options-object with the following attributes:
 | `dropTargetStyle` | Object&lt;String&gt; | No | `{outline: 'rgba(255, 255, 102, 0.7) solid 2px'}` | An object of styles to apply to the dnd-zone when items can be dragged into it. Note: the styles override any inline styles applied to the dnd-zone. When the styles are removed, any original inline styles will be lost |
 | `dropTargetClasses`| Array&lt;String&gt; | No | `[]` | A list of classes to apply to the dnd-zone when items can be dragged into it. Note: make sure the classes you use are global. |
 | `transformDraggedElement` | Function | No | `() => {}` | A function that is invoked when the draggable element enters the dnd-zone or hover overs a new index in the current dnd-zone. <br />Signature:<br />function(element, data, index) {}<br />**element**: The dragged element. <br />**data**: The data of the item from the items array.<br />**index**: The index the dragged element will become in the new dnd-zone.<br /><br />This allows you to override properties on the dragged element, such as innerHTML to change how it displays. If what you are after is altering styles, do it to the children, not to the dragged element itself |
-| `autoAriaDisabled` | Boolean | No | `false` | Setting it to true will disable all the automatically added aria attributes and aria alerts (for example when the user starts/ stops dragging using the keyboard).<br /> **Use it only if you intend to implement your own custom instructions, roles and alerts.** In such a case, you might find the exported function `alertToScreenReader(string)` useful. |
+| `autoAriaDisabled` | Boolean | No | `false` | Setting it to true will disable all the automatically added aria attributes and aria alerts (for example when the user starts/ stops dragging using the keyboard).<br /> **Use it only if you intend to implement your own custom instructions, roles and alerts.** In such a case, you might find the exported function `alertToScreenReader(string)` useful. <br />**If you only want to change the wording (ex: to translate it), use `setAriaStrings` instead and leave this off.** |
 | `centreDraggedOnCursor` | Boolean | No | `false` | Setting it to true will cause elements from this dnd-zone to position their center on the cursor on drag start, effectively turning the cursor to the focal point that triggers all the dnd events (ex: entering another zone). Useful for dnd-zones with large items that can be dragged over small items. |
 | `useCursorForDetection` | Boolean | No | `false` | Setting it to true will use the cursor position instead of the dragged element's center for drop zone detection. This improves accuracy when dragging large elements over small drop targets. Unlike `centreDraggedOnCursor`, this option does not reposition the dragged element. |
 | `dropAnimationDisabled` | Boolean | No | `false` | Setting it to true will disable the animation of the dropped element to its final place. |
@@ -166,6 +166,30 @@ For example:
 If you don't provide the aria-labels everything will still work, but the messages to the user will be less informative.
 _Note_: in general you probably want to use semantic-html (ex: `ol` and `li` elements rather than `section` and `div`) but the library is screen readers friendly regardless (or at least that's the goal :)).
 If you want to implement your own custom screen-reader alerts, roles and instructions, you can use the `autoAriaDisabled` options and wire everything up yourself using markup and the `consider` and `finalize` handlers (for example: [unsortable list](https://svelte.dev/playground/e020ea1051dc4ae3ac2b697064f234bc?version=3)).
+
+#### Translating the screen-reader messages
+
+`autoAriaDisabled` is all-or-nothing — it turns off the aria attributes, the roles and the instructions along with the alerts. If all you want is to change the _words_ (for example to ship the library in a language other than English), import `setAriaStrings` instead and keep everything else:
+
+```javascript
+import {setAriaStrings} from "svelte-dnd-action";
+
+setAriaStrings({
+    dragStarted: ({itemLabel, zoneLabel, canMoveBetweenZones}) =>
+        `Déplacement de ${itemLabel} commencé. Utilisez les flèches pour le déplacer dans la liste ${zoneLabel}` +
+        (canMoveBetweenZones ? `, ou tabulez vers une autre liste` : ``),
+    movedToPosition: ({itemLabel, zoneLabel, position}) => `${itemLabel} déplacé en position ${position} dans la liste ${zoneLabel}`,
+    movedToZoneEnd: ({itemLabel, zoneLabel}) => `${itemLabel} déplacé à la fin de la liste ${zoneLabel}`,
+    movedToZoneStart: ({itemLabel, zoneLabel}) => `${itemLabel} déplacé au début de la liste ${zoneLabel}`,
+    dropped: ({itemLabel}) => `Déplacement de ${itemLabel} terminé`,
+    zoneActiveInstruction: `Tabulez jusqu'à un élément et appuyez sur espace ou entrée pour le déplacer`,
+    zoneDragDisabledInstruction: `Cette liste de glisser-déposer est désactivée`
+});
+```
+
+Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation; they receive `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` for the move messages and `canMoveBetweenZones` for `dragStarted`.
+
+You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Pass `null` to go back to the built-in English. Passing an unrecognised key throws, so typos surface immediately.
 
 ##### Keyboard support
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ setAriaStrings({
 });
 ```
 
-Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation; `dragStarted`, `movedToPosition`, `movedToZoneEnd` and `movedToZoneStart` receive `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` for the move messages and `canMoveBetweenZones` for `dragStarted`; `dropped` receives only `itemLabel`.
+Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation. All five receive the same context: `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` — the item's 1-based seat in the zone the message is about, and how many items that zone holds. `dragStarted` additionally receives `canMoveBetweenZones`. The built-in English strings don't interpolate every field, but they are all supplied so you can word any message positionally, for example `` dropped: ({itemLabel, zoneLabel, position, count}) => `${itemLabel} déposé dans ${zoneLabel}, ${position} sur ${count}` ``.
 
 You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Pass `null` to go back to the built-in English. Passing an unrecognised key, or a value of the wrong type for its key, throws, so mistakes surface immediately. This is global and applies to all dndzones — you can't configure two zones with different aria strings.
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,14 @@ setAriaStrings({
     movedToPosition: ({itemLabel, zoneLabel, position}) => `${itemLabel} déplacé en position ${position} dans la liste ${zoneLabel}`,
     movedToZoneEnd: ({itemLabel, zoneLabel}) => `${itemLabel} déplacé à la fin de la liste ${zoneLabel}`,
     movedToZoneStart: ({itemLabel, zoneLabel}) => `${itemLabel} déplacé au début de la liste ${zoneLabel}`,
-    dropped: ({itemLabel}) => `Déplacement de ${itemLabel} terminé`,
+    // The defaults don't say where the item landed, but the context is there if you want it
+    dropped: ({itemLabel, zoneLabel, position, count}) => `${itemLabel} déposé dans ${zoneLabel}, ${position} sur ${count}`,
     zoneActiveInstruction: `Tabulez jusqu'à un élément et appuyez sur espace ou entrée pour le déplacer`,
     zoneDragDisabledInstruction: `Cette liste de glisser-déposer est désactivée`
 });
 ```
 
-Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation. All five receive the same context: `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` — the item's 1-based seat in the zone the message is about, and how many items that zone holds. `dragStarted` additionally receives `canMoveBetweenZones`. The built-in English strings don't interpolate every field, but they are all supplied so you can word any message positionally, for example `` dropped: ({itemLabel, zoneLabel, position, count}) => `${itemLabel} déposé dans ${zoneLabel}, ${position} sur ${count}` ``.
+Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation. All five receive the same context: `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` — the item's 1-based seat in the zone the message is about, and how many items that zone holds. `dragStarted` additionally receives `canMoveBetweenZones`. Destructure only what your wording needs — the built-in English strings don't interpolate every field, but they are all supplied so you can word any message positionally, as the `dropped` line above does.
 
 You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Pass `null` to go back to the built-in English. Passing an unrecognised key, or a value of the wrong type for its key, throws, so mistakes surface immediately. This is global and applies to all dndzones — you can't configure two zones with different aria strings.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ setAriaStrings({
 
 Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation. All five receive the same context: `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` — the item's 1-based seat in the zone the message is about, and how many items that zone holds. `dragStarted` additionally receives `canMoveBetweenZones`. Destructure only what your wording needs — the built-in English strings don't interpolate every field, but they are all supplied so you can word any message positionally, as the `dropped` line above does.
 
-You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Pass `null` to go back to the built-in English. Passing an unrecognised key, or a value of the wrong type for its key, throws, so mistakes surface immediately. This is global and applies to all dndzones — you can't configure two zones with different aria strings.
+You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Each call describes a whole locale rather than patching the previous one: the overrides are merged over the English defaults, not over whatever was set last, so a key your new locale is silent about goes back to English instead of staying in the old language. Pass `null` to go back to the built-in English. Passing an unrecognised key, or a value of the wrong type for its key, throws, so mistakes surface immediately. This is global and applies to all dndzones — you can't configure two zones with different aria strings.
 
 ##### Keyboard support
 

--- a/cypress/integration/aria.spec.js
+++ b/cypress/integration/aria.spec.js
@@ -102,12 +102,29 @@ describe("aria strings", () => {
         expect(alertText(), "an invalid call should not touch the existing table").to.equal("Carte A déposé");
     });
 
-    it("can be called again to switch locale", () => {
-        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
-        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} abgelegt`});
+    it("treats each call as a whole locale, not a patch on the previous one", () => {
+        // Switching locale exercises three kinds of key at once, and only the first survives a merge
+        // over the *current* table: one both locales name, one only the new locale names, and one only
+        // the old locale named. That last kind is the leak - two locale files rarely override the exact
+        // same subset, so the keys the new one is silent about would keep speaking the old language.
+        setAriaStrings({
+            dropped: ({itemLabel}) => `${itemLabel} déposé`,
+            zoneActiveInstruction: "Tabulez jusqu'à un élément et appuyez sur espace"
+        });
+        setAriaStrings({
+            dropped: ({itemLabel}) => `${itemLabel} abgelegt`,
+            movedToZoneEnd: ({itemLabel, zoneLabel}) => `${itemLabel} ans Ende der Liste ${zoneLabel} verschoben`
+        });
 
         announceToScreenReader("dropped", {itemLabel: "Karte A"});
-        expect(alertText()).to.equal("Karte A abgelegt");
+        expect(alertText(), "a key both locales name should speak the new one").to.equal("Karte A abgelegt");
+
+        announceToScreenReader("movedToZoneEnd", {itemLabel: "Karte A", zoneLabel: "Fertig", position: 3, count: 3});
+        expect(alertText(), "a key only the new locale names should take effect").to.equal("Karte A ans Ende der Liste Fertig verschoben");
+
+        expect(document.getElementById(ZONE_ACTIVE_ID).textContent, "a key only the old locale named should be English again, not French").to.equal(
+            "Tab to one the items and press space-bar or enter to start dragging it"
+        );
     });
 
     it("resets to the defaults when passed null", () => {

--- a/cypress/integration/aria.spec.js
+++ b/cypress/integration/aria.spec.js
@@ -63,6 +63,45 @@ describe("aria strings", () => {
         expect(() => setAriaStrings({onDrop: () => "nope"})).to.throw("movedToPosition");
     });
 
+    it("throws when a message key is given a non-function value", () => {
+        // A locale file missing a key would otherwise silently install `undefined`, and the screen
+        // reader would speak the literal word "undefined" on every drop.
+        expect(() => setAriaStrings({dropped: undefined})).to.throw("dropped");
+        expect(() => setAriaStrings({dropped: "Stopped dragging"})).to.throw("dropped");
+    });
+
+    it("throws when an instruction key is given a non-string value", () => {
+        // A natural mistake since the other five keys are functions - this would otherwise read the
+        // literal source text of the function aloud to every screen-reader user who tabs into a zone.
+        expect(() => setAriaStrings({zoneActiveInstruction: () => "Tab to an item"})).to.throw("zoneActiveInstruction");
+    });
+
+    it("leaves the string table untouched when a value fails validation", () => {
+        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
+
+        expect(() =>
+            setAriaStrings({
+                dropped: ({itemLabel}) => `${itemLabel} abgelegt`,
+                zoneActiveInstruction: () => "not a string"
+            })
+        ).to.throw("zoneActiveInstruction");
+
+        announceToScreenReader("dropped", {itemLabel: "Carte A"});
+        expect(alertText(), "the earlier valid override should survive a later failed call untouched").to.equal("Carte A déposé");
+    });
+
+    it("throws a clear error for non-object arguments instead of silently no-oping", () => {
+        // null/undefined are the legitimate "reset to defaults" signal and must keep working.
+        expect(() => setAriaStrings(42)).to.throw("42");
+        expect(() => setAriaStrings([])).to.throw("setAriaStrings");
+        expect(() => setAriaStrings("fr")).to.throw("setAriaStrings");
+
+        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
+        expect(() => setAriaStrings("fr")).to.throw("setAriaStrings");
+        announceToScreenReader("dropped", {itemLabel: "Carte A"});
+        expect(alertText(), "an invalid call should not touch the existing table").to.equal("Carte A déposé");
+    });
+
     it("can be called again to switch locale", () => {
         setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
         setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} abgelegt`});

--- a/cypress/integration/aria.spec.js
+++ b/cypress/integration/aria.spec.js
@@ -1,0 +1,99 @@
+import {initAria, destroyAria, setAriaStrings, announceToScreenReader} from "../../src/helpers/aria";
+
+describe("aria strings", () => {
+    const ALERT_DIV_ID = "dnd-action-aria-alert";
+    const ZONE_ACTIVE_ID = "dnd-zone-active";
+    const ZONE_DRAG_DISABLED_ID = "dnd-zone-drag-disabled";
+
+    function alertText() {
+        return document.getElementById(ALERT_DIV_ID).textContent;
+    }
+
+    beforeEach(() => {
+        initAria();
+    });
+
+    afterEach(() => {
+        setAriaStrings(null);
+        destroyAria();
+    });
+
+    it("uses the stock English strings by default", () => {
+        announceToScreenReader("dragStarted", {itemLabel: "Card A", zoneLabel: "To do", canMoveBetweenZones: false});
+        expect(alertText()).to.equal("Started dragging item Card A. Use the arrow keys to move it within its list To do");
+
+        announceToScreenReader("dragStarted", {itemLabel: "Card A", zoneLabel: "To do", canMoveBetweenZones: true});
+        expect(alertText()).to.equal(
+            "Started dragging item Card A. Use the arrow keys to move it within its list To do, or tab to another list in order to move the item into it"
+        );
+
+        announceToScreenReader("movedToPosition", {itemLabel: "Card A", zoneLabel: "To do", position: 2, count: 3});
+        expect(alertText()).to.equal("Moved item Card A to position 2 in the list To do");
+
+        announceToScreenReader("movedToZoneEnd", {itemLabel: "Card A", zoneLabel: "Done", position: 3, count: 3});
+        expect(alertText()).to.equal("Moved item Card A to the end of the list Done");
+
+        announceToScreenReader("movedToZoneStart", {itemLabel: "Card A", zoneLabel: "Done", position: 1, count: 3});
+        expect(alertText()).to.equal("Moved item Card A to the beginning of the list Done");
+
+        announceToScreenReader("dropped", {itemLabel: "Card A"});
+        expect(alertText()).to.equal("Stopped dragging item Card A");
+
+        expect(document.getElementById(ZONE_ACTIVE_ID).textContent).to.equal(
+            "Tab to one the items and press space-bar or enter to start dragging it"
+        );
+        expect(document.getElementById(ZONE_DRAG_DISABLED_ID).textContent).to.equal("This is a disabled drag and drop list");
+    });
+
+    it("overrides only the keys it is given", () => {
+        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
+
+        announceToScreenReader("dropped", {itemLabel: "Carte A"});
+        expect(alertText()).to.equal("Carte A déposé");
+
+        announceToScreenReader("movedToPosition", {itemLabel: "Card A", zoneLabel: "To do", position: 2, count: 3});
+        expect(alertText(), "should leave un-overridden keys at their defaults").to.equal("Moved item Card A to position 2 in the list To do");
+    });
+
+    it("throws on an unknown key and names the supported ones", () => {
+        // Note: matched via substring rather than `.to.throw(/regex/)` - the Cypress version pinned in this
+        // repo (15.18.1) has a bug where chai's throw assertion never matches a RegExp errMsgMatcher, even
+        // for a bare `throw new Error(...)` with no involvement of this library's code.
+        expect(() => setAriaStrings({onDrop: () => "nope"})).to.throw("onDrop");
+        expect(() => setAriaStrings({onDrop: () => "nope"})).to.throw("movedToPosition");
+    });
+
+    it("can be called again to switch locale", () => {
+        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
+        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} abgelegt`});
+
+        announceToScreenReader("dropped", {itemLabel: "Karte A"});
+        expect(alertText()).to.equal("Karte A abgelegt");
+    });
+
+    it("resets to the defaults when passed null", () => {
+        setAriaStrings({dropped: ({itemLabel}) => `${itemLabel} déposé`});
+        setAriaStrings(null);
+
+        announceToScreenReader("dropped", {itemLabel: "Card A"});
+        expect(alertText()).to.equal("Stopped dragging item Card A");
+    });
+
+    it("rewrites the live instruction divs when the locale changes mid-session", () => {
+        setAriaStrings({
+            zoneActiveInstruction: "Tabulez jusqu'à un élément et appuyez sur espace",
+            zoneDragDisabledInstruction: "Cette liste est désactivée"
+        });
+
+        expect(document.getElementById(ZONE_ACTIVE_ID).textContent).to.equal("Tabulez jusqu'à un élément et appuyez sur espace");
+        expect(document.getElementById(ZONE_DRAG_DISABLED_ID).textContent).to.equal("Cette liste est désactivée");
+    });
+
+    it("renders instruction strings as text, not markup", () => {
+        setAriaStrings({zoneActiveInstruction: "<img src=x onerror=alert(1)> press space"});
+
+        const div = document.getElementById(ZONE_ACTIVE_ID);
+        expect(div.querySelectorAll("img").length, "should not build elements from the string").to.equal(0);
+        expect(div.textContent).to.equal("<img src=x onerror=alert(1)> press space");
+    });
+});

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -246,6 +246,28 @@ describe("keyboardAction", () => {
             expect(seen).to.deep.equal(["grab:Card 0:To do:false", "move:Card 0:To do:2:2", "drop:Card 0"]);
         });
 
+        it("gives the grab and the drop the item's seat and the zone's size", () => {
+            const seen = [];
+            setAriaStrings({
+                dragStarted: ctx => `grab:${ctx.zoneLabel}:${ctx.position}:${ctx.count}`,
+                dropped: ctx => `drop:${ctx.zoneLabel}:${ctx.position}:${ctx.count}`
+            });
+            const {
+                children: [, second]
+            } = createLabelledZone([{id: "a"}, {id: "b"}, {id: "c"}], "To do");
+
+            grab(second);
+            seen.push(alertText());
+            second.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown", bubbles: true, cancelable: true}));
+            second.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+            seen.push(alertText());
+
+            // Lifted from seat 2 of 3 and dropped into seat 3 of 3. Both are read off the live
+            // items rather than assumed, so a hardcoded position or a stale count fails here
+            // instead of passing quietly - which a single-item zone would not catch.
+            expect(seen).to.deep.equal(["grab:To do:2:3", "drop:To do:3:3"]);
+        });
+
         it("reports canMoveBetweenZones when another zone can accept the item", () => {
             setAriaStrings({dragStarted: ctx => `${ctx.canMoveBetweenZones}`});
             const {

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -1,5 +1,6 @@
 import {dndzone} from "../../src/keyboardAction";
 import {TRIGGERS} from "../../src/constants";
+import {setAriaStrings} from "../../src/helpers/aria";
 
 describe("keyboardAction", () => {
     const actions = [];
@@ -218,6 +219,75 @@ describe("keyboardAction", () => {
             item.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown", bubbles: true, cancelable: true}));
 
             expect(alertText()).to.equal("Moved item Card 0 to position 2 in the list To do");
+        });
+
+        afterEach(() => {
+            setAriaStrings(null);
+        });
+
+        it("routes every announcement through the overridable strings", () => {
+            const seen = [];
+            setAriaStrings({
+                dragStarted: ctx => `grab:${ctx.itemLabel}:${ctx.zoneLabel}:${ctx.canMoveBetweenZones}`,
+                movedToPosition: ctx => `move:${ctx.itemLabel}:${ctx.zoneLabel}:${ctx.position}:${ctx.count}`,
+                dropped: ctx => `drop:${ctx.itemLabel}`
+            });
+            const {
+                children: [item]
+            } = createLabelledZone([{id: "a"}, {id: "b"}], "To do");
+
+            grab(item);
+            seen.push(alertText());
+            item.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown", bubbles: true, cancelable: true}));
+            seen.push(alertText());
+            item.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+            seen.push(alertText());
+
+            expect(seen).to.deep.equal(["grab:Card 0:To do:false", "move:Card 0:To do:2:2", "drop:Card 0"]);
+        });
+
+        it("reports canMoveBetweenZones when another zone can accept the item", () => {
+            setAriaStrings({dragStarted: ctx => `${ctx.canMoveBetweenZones}`});
+            const {
+                children: [item]
+            } = createLabelledZone([{id: "a"}], "To do");
+            createLabelledZone([], "Done");
+
+            grab(item);
+
+            expect(alertText()).to.equal("true");
+        });
+
+        it("uses the cross-zone strings when focus moves to another zone", () => {
+            setAriaStrings({
+                movedToZoneEnd: ctx => `end:${ctx.itemLabel}:${ctx.zoneLabel}:${ctx.position}:${ctx.count}`,
+                movedToZoneStart: ctx => `start:${ctx.itemLabel}:${ctx.zoneLabel}:${ctx.position}:${ctx.count}`
+            });
+            const {zone: zoneA, children: itemsA} = createLabelledZone([{id: "a"}], "To do");
+            const {zone: zoneB} = createLabelledZone([{id: "b"}], "Done");
+
+            // zoneB renders below zoneA, so moving into it is a move to the beginning.
+            grab(itemsA[0]);
+            zoneB.dispatchEvent(new FocusEvent("focus"));
+            expect(alertText()).to.equal("start:Card 0:Done:1:2");
+
+            // These zones have no visible content, so both collapse to the same (0) top/left in
+            // the real browser layout Cypress renders. handleZoneFocus's `top <`/`left <` check
+            // never fires true either direction, so every zone-to-zone move here takes the
+            // "unshift" branch (movedToZoneStart) - moving back up into zoneA is no exception.
+            zoneA.dispatchEvent(new FocusEvent("focus"));
+            expect(alertText()).to.equal("start:Card 0:To do:1:1");
+        });
+
+        it("stays silent when autoAriaDisabled is set, even with overrides installed", () => {
+            setAriaStrings({dragStarted: () => "SHOULD NOT BE SPOKEN"});
+            const {
+                children: [item]
+            } = createLabelledZone([{id: "a"}], "To do", {autoAriaDisabled: true});
+
+            grab(item);
+
+            expect(document.getElementById("dnd-action-aria-alert").textContent).to.equal("");
         });
     });
 });

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -265,18 +265,22 @@ describe("keyboardAction", () => {
             });
             const {zone: zoneA, children: itemsA} = createLabelledZone([{id: "a"}], "To do");
             const {zone: zoneB} = createLabelledZone([{id: "b"}], "Done");
+            // The zones otherwise have no visible content, so both would collapse to the same
+            // (0,0) top/left and handleZoneFocus's `top <`/`left <` check would never fire true
+            // either direction. Give them real, distinct layout so zoneA genuinely sits above
+            // zoneB - that's what makes the two branches (movedToZoneStart / movedToZoneEnd)
+            // actually distinguishable here.
+            zoneA.style.height = "50px";
+            zoneB.style.height = "50px";
 
             // zoneB renders below zoneA, so moving into it is a move to the beginning.
             grab(itemsA[0]);
             zoneB.dispatchEvent(new FocusEvent("focus"));
             expect(alertText()).to.equal("start:Card 0:Done:1:2");
 
-            // These zones have no visible content, so both collapse to the same (0) top/left in
-            // the real browser layout Cypress renders. handleZoneFocus's `top <`/`left <` check
-            // never fires true either direction, so every zone-to-zone move here takes the
-            // "unshift" branch (movedToZoneStart) - moving back up into zoneA is no exception.
+            // and moving back up into zoneA - which sits above zoneB - is a move to the end.
             zoneA.dispatchEvent(new FocusEvent("focus"));
-            expect(alertText()).to.equal("start:Card 0:To do:1:1");
+            expect(alertText()).to.equal("end:Card 0:To do:1:1");
         });
 
         it("stays silent when autoAriaDisabled is set, even with overrides installed", () => {

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -184,6 +184,10 @@ describe("keyboardAction", () => {
     });
 
     describe("announcements", () => {
+        afterEach(() => {
+            setAriaStrings(null);
+        });
+
         function alertText() {
             return document.getElementById("dnd-action-aria-alert").textContent;
         }
@@ -219,10 +223,6 @@ describe("keyboardAction", () => {
             item.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown", bubbles: true, cancelable: true}));
 
             expect(alertText()).to.equal("Moved item Card 0 to position 2 in the list To do");
-        });
-
-        afterEach(() => {
-            setAriaStrings(null);
         });
 
         it("routes every announcement through the overridable strings", () => {
@@ -292,6 +292,57 @@ describe("keyboardAction", () => {
             grab(item);
 
             expect(document.getElementById("dnd-action-aria-alert").textContent).to.equal("");
+        });
+
+        it("does not get stuck dragging when a consumer formatter throws on drop, and announces the default instead", () => {
+            setAriaStrings({
+                dropped: () => {
+                    throw new Error("boom");
+                }
+            });
+            const {
+                zone,
+                children: [item]
+            } = createLabelledZone([{id: "a"}, {id: "b"}], "To do");
+            const triggers = [];
+            zone.addEventListener("consider", e => triggers.push(e.detail.info.trigger));
+
+            grab(item);
+            item.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
+
+            expect(alertText(), "should fall back to the default text instead of staying silent or speaking undefined").to.equal(
+                "Stopped dragging item Card 0"
+            );
+            expect(triggers, "the drop should still have dispatched the drag-stopped consider event").to.include(TRIGGERS.DRAG_STOPPED);
+            expect(zone.tabIndex, "the drop should have completed and restored the zone's tab index").to.equal(0);
+            expect(item.tabIndex, "the drop should have completed and restored the item's tab index").to.equal(0);
+
+            // A fresh grab proves the library isn't wedged in isDragging:true - if it were, pressing
+            // space would be routed to another drop (handleKeyDown treats space-while-dragging as a
+            // drop), not a new drag-started announcement.
+            setAriaStrings(null);
+            grab(item);
+            expect(alertText(), "a fresh grab afterwards should start a new drag rather than drop again").to.equal(
+                "Started dragging item Card 0. Use the arrow keys to move it within its list To do"
+            );
+        });
+
+        it("does not throw when a consumer formatter throws while a zone is destroyed mid-drag", () => {
+            setAriaStrings({
+                dropped: () => {
+                    throw new Error("boom");
+                }
+            });
+            const {
+                action,
+                children: [item]
+            } = createLabelledZone([{id: "a"}], "To do");
+
+            grab(item);
+
+            // unregisterDropZone calls handleDrop synchronously when the focused zone is destroyed
+            // mid-drag; a throwing formatter must not break component teardown.
+            expect(() => action.destroy()).to.not.throw();
         });
     });
 });

--- a/src/helpers/aria.js
+++ b/src/helpers/aria.js
@@ -115,9 +115,11 @@ export function alertToScreenReader(txt) {
 }
 
 /**
- * Overrides the strings the library speaks to screen readers. Merges over the current strings, so you
- * can translate one message without restating the rest. Can be called at any time - including again on
- * a locale change, which also re-renders the static instructions that are already in the DOM.
+ * Overrides the strings the library speaks to screen readers. Merges over the built-in English defaults,
+ * so you can translate one message without restating the rest. Each call describes a whole locale rather
+ * than patching the previous one - anything a call leaves out goes back to English, so switching between
+ * two partial locales can't leave keys behind speaking the old language. Can be called at any time -
+ * including again on a locale change, which also re-renders the static instructions already in the DOM.
  * This is global and applies to all dndzones.
  * Pass null to restore the built-in English strings.
  * @param {Object | null} overrides - any subset of: dragStarted, movedToPosition, movedToZoneEnd,
@@ -145,7 +147,7 @@ export function setAriaStrings(overrides) {
                 throw new Error(`${key} should be a string but instead it is a ${typeof value}, ${toString(value)}`);
             }
         });
-        ariaStrings = {...ariaStrings, ...overrides};
+        ariaStrings = {...DEFAULT_ARIA_STRINGS, ...overrides};
     }
     if (isOnServer) return;
     Object.entries(INSTRUCTION_ID_TO_STRING_KEY).forEach(([id, key]) => {

--- a/src/helpers/aria.js
+++ b/src/helpers/aria.js
@@ -4,10 +4,24 @@ const INSTRUCTION_IDs = {
     DND_ZONE_ACTIVE: "dnd-zone-active",
     DND_ZONE_DRAG_DISABLED: "dnd-zone-drag-disabled"
 };
-const ID_TO_INSTRUCTION = {
-    [INSTRUCTION_IDs.DND_ZONE_ACTIVE]: "Tab to one the items and press space-bar or enter to start dragging it",
-    [INSTRUCTION_IDs.DND_ZONE_DRAG_DISABLED]: "This is a disabled drag and drop list"
+const INSTRUCTION_ID_TO_STRING_KEY = {
+    [INSTRUCTION_IDs.DND_ZONE_ACTIVE]: "zoneActiveInstruction",
+    [INSTRUCTION_IDs.DND_ZONE_DRAG_DISABLED]: "zoneDragDisabledInstruction"
 };
+
+const DEFAULT_ARIA_STRINGS = {
+    dragStarted: ({itemLabel, zoneLabel, canMoveBetweenZones}) =>
+        `Started dragging item ${itemLabel}. Use the arrow keys to move it within its list ${zoneLabel}` +
+        (canMoveBetweenZones ? ", or tab to another list in order to move the item into it" : ""),
+    movedToPosition: ({itemLabel, zoneLabel, position}) => `Moved item ${itemLabel} to position ${position} in the list ${zoneLabel}`,
+    movedToZoneEnd: ({itemLabel, zoneLabel}) => `Moved item ${itemLabel} to the end of the list ${zoneLabel}`,
+    movedToZoneStart: ({itemLabel, zoneLabel}) => `Moved item ${itemLabel} to the beginning of the list ${zoneLabel}`,
+    dropped: ({itemLabel}) => `Stopped dragging item ${itemLabel}`,
+    zoneActiveInstruction: "Tab to one the items and press space-bar or enter to start dragging it",
+    zoneDragDisabledInstruction: "This is a disabled drag and drop list"
+};
+
+let ariaStrings = {...DEFAULT_ARIA_STRINGS};
 
 const ALERT_DIV_ID = "dnd-action-aria-alert";
 let alertsDiv;
@@ -35,7 +49,7 @@ function initAriaOnBrowser() {
     document.body.prepend(alertsDiv);
 
     // setting the instructions
-    Object.entries(ID_TO_INSTRUCTION).forEach(([id, txt]) => document.body.prepend(instructionToHiddenDiv(id, txt)));
+    Object.entries(INSTRUCTION_ID_TO_STRING_KEY).forEach(([id, key]) => document.body.prepend(instructionToHiddenDiv(id, ariaStrings[key])));
 }
 
 /**
@@ -57,7 +71,7 @@ export function initAria() {
  */
 export function destroyAria() {
     if (isOnServer || !alertsDiv) return;
-    Object.keys(ID_TO_INSTRUCTION).forEach(id => document.getElementById(id)?.remove());
+    Object.keys(INSTRUCTION_ID_TO_STRING_KEY).forEach(id => document.getElementById(id)?.remove());
     alertsDiv.remove();
     alertsDiv = undefined;
 }
@@ -65,11 +79,18 @@ export function destroyAria() {
 function instructionToHiddenDiv(id, txt) {
     const div = document.createElement("div");
     div.id = id;
-    div.innerHTML = `<p>${txt}</p>`;
+    renderInstruction(div, txt);
     div.style.display = "none";
     div.style.position = "fixed";
     div.style.zIndex = "-5";
     return div;
+}
+
+function renderInstruction(div, txt) {
+    div.innerHTML = "";
+    const paragraph = document.createElement("p");
+    paragraph.textContent = txt;
+    div.appendChild(paragraph);
 }
 
 /**
@@ -87,4 +108,41 @@ export function alertToScreenReader(txt) {
     // this is needed for Safari
     alertsDiv.style.display = "none";
     alertsDiv.style.display = "inline";
+}
+
+/**
+ * Overrides the strings the library speaks to screen readers. Merges over the current strings, so you
+ * can translate one message without restating the rest. Can be called at any time - including again on
+ * a locale change, which also re-renders the static instructions that are already in the DOM.
+ * Pass null to restore the built-in English strings.
+ * @param {Object | null} overrides - any subset of: dragStarted, movedToPosition, movedToZoneEnd,
+ * movedToZoneStart, dropped (functions taking a context object and returning a string);
+ * zoneActiveInstruction, zoneDragDisabledInstruction (strings)
+ */
+export function setAriaStrings(overrides) {
+    if (overrides === null || overrides === undefined) {
+        ariaStrings = {...DEFAULT_ARIA_STRINGS};
+    } else {
+        Object.keys(overrides).forEach(key => {
+            if (!Object.prototype.hasOwnProperty.call(DEFAULT_ARIA_STRINGS, key)) {
+                throw new Error(`Can't set non existing aria string ${key}! Supported strings: ${Object.keys(DEFAULT_ARIA_STRINGS)}`);
+            }
+        });
+        ariaStrings = {...ariaStrings, ...overrides};
+    }
+    if (isOnServer) return;
+    Object.entries(INSTRUCTION_ID_TO_STRING_KEY).forEach(([id, key]) => {
+        const div = document.getElementById(id);
+        if (div) renderInstruction(div, ariaStrings[key]);
+    });
+}
+
+/**
+ * Formats one of the aria strings and alerts it to the screen reader
+ * @param {string} key - one of the keys accepted by setAriaStrings
+ * @param {Object} [ctx] - the interpolation context for that key
+ */
+export function announceToScreenReader(key, ctx) {
+    const ariaString = ariaStrings[key];
+    alertToScreenReader(typeof ariaString === "function" ? ariaString(ctx) : ariaString);
 }

--- a/src/helpers/aria.js
+++ b/src/helpers/aria.js
@@ -1,4 +1,5 @@
-import {isOnServer} from "../constants";
+import {isOnServer, printDebug} from "../constants";
+import {toString} from "./util";
 
 const INSTRUCTION_IDs = {
     DND_ZONE_ACTIVE: "dnd-zone-active",
@@ -20,6 +21,9 @@ const DEFAULT_ARIA_STRINGS = {
     zoneActiveInstruction: "Tab to one the items and press space-bar or enter to start dragging it",
     zoneDragDisabledInstruction: "This is a disabled drag and drop list"
 };
+
+const FUNCTION_ARIA_STRING_KEYS = ["dragStarted", "movedToPosition", "movedToZoneEnd", "movedToZoneStart", "dropped"];
+const STRING_ARIA_STRING_KEYS = ["zoneActiveInstruction", "zoneDragDisabledInstruction"];
 
 let ariaStrings = {...DEFAULT_ARIA_STRINGS};
 
@@ -87,7 +91,7 @@ function instructionToHiddenDiv(id, txt) {
 }
 
 function renderInstruction(div, txt) {
-    div.innerHTML = "";
+    div.replaceChildren();
     const paragraph = document.createElement("p");
     paragraph.textContent = txt;
     div.appendChild(paragraph);
@@ -114,18 +118,31 @@ export function alertToScreenReader(txt) {
  * Overrides the strings the library speaks to screen readers. Merges over the current strings, so you
  * can translate one message without restating the rest. Can be called at any time - including again on
  * a locale change, which also re-renders the static instructions that are already in the DOM.
+ * This is global and applies to all dndzones.
  * Pass null to restore the built-in English strings.
  * @param {Object | null} overrides - any subset of: dragStarted, movedToPosition, movedToZoneEnd,
  * movedToZoneStart, dropped (functions taking a context object and returning a string);
  * zoneActiveInstruction, zoneDragDisabledInstruction (strings)
+ * @throws {Error} if given something other than an object or null, an unknown key, or a value of the wrong
+ * type for its key (a partially-applied table is never left behind - the whole call is validated first)
  */
 export function setAriaStrings(overrides) {
     if (overrides === null || overrides === undefined) {
         ariaStrings = {...DEFAULT_ARIA_STRINGS};
     } else {
+        if (typeof overrides !== "object" || Array.isArray(overrides)) {
+            throw new Error(`setAriaStrings expects an object or null but instead got a ${typeof overrides}, ${toString(overrides)}`);
+        }
         Object.keys(overrides).forEach(key => {
             if (!Object.prototype.hasOwnProperty.call(DEFAULT_ARIA_STRINGS, key)) {
                 throw new Error(`Can't set non existing aria string ${key}! Supported strings: ${Object.keys(DEFAULT_ARIA_STRINGS)}`);
+            }
+            const value = overrides[key];
+            if (FUNCTION_ARIA_STRING_KEYS.includes(key) && typeof value !== "function") {
+                throw new Error(`${key} should be a function but instead it is a ${typeof value}, ${toString(value)}`);
+            }
+            if (STRING_ARIA_STRING_KEYS.includes(key) && typeof value !== "string") {
+                throw new Error(`${key} should be a string but instead it is a ${typeof value}, ${toString(value)}`);
             }
         });
         ariaStrings = {...ariaStrings, ...overrides};
@@ -137,12 +154,32 @@ export function setAriaStrings(overrides) {
     });
 }
 
+function formatAriaString(strings, key, ctx) {
+    const ariaString = strings[key];
+    return typeof ariaString === "function" ? ariaString(ctx) : ariaString;
+}
+
 /**
- * Formats one of the aria strings and alerts it to the screen reader
+ * Formats one of the aria strings and alerts it to the screen reader. A consumer-supplied formatter
+ * (installed via setAriaStrings) is never allowed to throw out of here - this runs inside the drag
+ * lifecycle (ex: handleDrop), and letting an exception escape would leave the library stuck mid-drag.
+ * If the consumer's formatter throws, we fall back to the built-in default for that key (itself guarded)
+ * and report the swallowed error via printDebug.
  * @param {string} key - one of the keys accepted by setAriaStrings
  * @param {Object} [ctx] - the interpolation context for that key
  */
 export function announceToScreenReader(key, ctx) {
-    const ariaString = ariaStrings[key];
-    alertToScreenReader(typeof ariaString === "function" ? ariaString(ctx) : ariaString);
+    let text;
+    try {
+        text = formatAriaString(ariaStrings, key, ctx);
+    } catch (err) {
+        printDebug(() => [`aria string formatter for "${key}" threw, falling back to the default`, err]);
+        try {
+            text = formatAriaString(DEFAULT_ARIA_STRINGS, key, ctx);
+        } catch (defaultErr) {
+            printDebug(() => [`default aria string formatter for "${key}" also threw`, defaultErr]);
+            text = "";
+        }
+    }
+    alertToScreenReader(text);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export {dndzone} from "./action.js";
 export {dragHandleZone, dragHandle} from "./wrappers/withDragHandles";
-export {alertToScreenReader} from "./helpers/aria";
+export {alertToScreenReader, setAriaStrings} from "./helpers/aria";
 export {
     TRIGGERS,
     SOURCES,

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -165,7 +165,17 @@ function handleDrop(dispatchConsider = true) {
     if (!droppedConfig) return;
 
     if (!droppedConfig.autoAriaDisabled) {
-        announceToScreenReader("dropped", {itemLabel: focusedItemLabel});
+        // Same context as the move messages: where the item came to rest is the news, and a
+        // consumer that words the drop ("Dropped in Done, 2 of 5") needs the zone and the
+        // seat, not just the item. `focusedDzLabel` tracks focusedDz, which droppedDz is.
+        const droppedItems = droppedConfig.items;
+        const droppedIdx = droppedItems.findIndex(item => item[ITEM_ID_KEY] === droppedItemId);
+        announceToScreenReader("dropped", {
+            itemLabel: focusedItemLabel,
+            zoneLabel: focusedDzLabel,
+            position: (droppedIdx < 0 ? 0 : droppedIdx) + 1,
+            count: droppedItems.length
+        });
     }
     if (allDragTargets.has(document.activeElement)) {
         document.activeElement.blur();
@@ -299,9 +309,15 @@ export function dndzone(node, options) {
             dz => dzToConfig.get(dz).dropTargetClasses
         );
         if (!config.autoAriaDisabled) {
+            // The seat the item is lifted FROM, so a consumer can open with it ("Picked up
+            // Card A. To do, 1 of 5") — the most common reason to override this string.
+            const startItems = dzToConfig.get(node).items;
+            const startIdx = startItems.findIndex(item => item[ITEM_ID_KEY] === focusedItemId);
             announceToScreenReader("dragStarted", {
                 itemLabel: focusedItemLabel,
                 zoneLabel: focusedDzLabel,
+                position: (startIdx < 0 ? 0 : startIdx) + 1,
+                count: startItems.length,
                 canMoveBetweenZones: dropTargets.length > 1
             });
         }

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -1,7 +1,7 @@
 import {decrementActiveDropZoneCount, incrementActiveDropZoneCount, ITEM_ID_KEY, SOURCES, TRIGGERS} from "./constants";
 import {styleActiveDropZones, styleInactiveDropZones} from "./helpers/styler";
 import {dispatchConsiderEvent, dispatchFinalizeEvent} from "./helpers/dispatcher";
-import {initAria, alertToScreenReader, destroyAria} from "./helpers/aria";
+import {initAria, announceToScreenReader, destroyAria} from "./helpers/aria";
 import {toString} from "./helpers/util";
 import {printDebug} from "./constants";
 
@@ -124,12 +124,22 @@ function handleZoneFocus(e) {
     ) {
         targetItems.push(itemToMove);
         if (!autoAriaDisabled) {
-            alertToScreenReader(`Moved item ${focusedItemLabel} to the end of the list ${focusedDzLabel}`);
+            announceToScreenReader("movedToZoneEnd", {
+                itemLabel: focusedItemLabel,
+                zoneLabel: focusedDzLabel,
+                position: targetItems.length,
+                count: targetItems.length
+            });
         }
     } else {
         targetItems.unshift(itemToMove);
         if (!autoAriaDisabled) {
-            alertToScreenReader(`Moved item ${focusedItemLabel} to the beginning of the list ${focusedDzLabel}`);
+            announceToScreenReader("movedToZoneStart", {
+                itemLabel: focusedItemLabel,
+                zoneLabel: focusedDzLabel,
+                position: 1,
+                count: targetItems.length
+            });
         }
     }
     const dzFrom = focusedDz;
@@ -155,7 +165,7 @@ function handleDrop(dispatchConsider = true) {
     if (!droppedConfig) return;
 
     if (!droppedConfig.autoAriaDisabled) {
-        alertToScreenReader(`Stopped dragging item ${focusedItemLabel}`);
+        announceToScreenReader("dropped", {itemLabel: focusedItemLabel});
     }
     if (allDragTargets.has(document.activeElement)) {
         document.activeElement.blur();
@@ -238,7 +248,12 @@ export function dndzone(node, options) {
                 printDebug(() => ["arrow down", idx]);
                 if (idx < children.length - 1) {
                     if (!config.autoAriaDisabled) {
-                        alertToScreenReader(`Moved item ${focusedItemLabel} to position ${idx + 2} in the list ${focusedDzLabel}`);
+                        announceToScreenReader("movedToPosition", {
+                            itemLabel: focusedItemLabel,
+                            zoneLabel: focusedDzLabel,
+                            position: idx + 2,
+                            count: items.length
+                        });
                     }
                     swap(items, idx, idx + 1);
                     dispatchFinalizeEvent(node, items, {trigger: TRIGGERS.DROPPED_INTO_ZONE, id: focusedItemId, source: SOURCES.KEYBOARD});
@@ -256,7 +271,12 @@ export function dndzone(node, options) {
                 printDebug(() => ["arrow up", idx]);
                 if (idx > 0) {
                     if (!config.autoAriaDisabled) {
-                        alertToScreenReader(`Moved item ${focusedItemLabel} to position ${idx} in the list ${focusedDzLabel}`);
+                        announceToScreenReader("movedToPosition", {
+                            itemLabel: focusedItemLabel,
+                            zoneLabel: focusedDzLabel,
+                            position: idx,
+                            count: items.length
+                        });
                     }
                     swap(items, idx, idx - 1);
                     dispatchFinalizeEvent(node, items, {trigger: TRIGGERS.DROPPED_INTO_ZONE, id: focusedItemId, source: SOURCES.KEYBOARD});
@@ -279,11 +299,11 @@ export function dndzone(node, options) {
             dz => dzToConfig.get(dz).dropTargetClasses
         );
         if (!config.autoAriaDisabled) {
-            let msg = `Started dragging item ${focusedItemLabel}. Use the arrow keys to move it within its list ${focusedDzLabel}`;
-            if (dropTargets.length > 1) {
-                msg += `, or tab to another list in order to move the item into it`;
-            }
-            alertToScreenReader(msg);
+            announceToScreenReader("dragStarted", {
+                itemLabel: focusedItemLabel,
+                zoneLabel: focusedDzLabel,
+                canMoveBetweenZones: dropTargets.length > 1
+            });
         }
         dispatchConsiderEvent(node, dzToConfig.get(node).items, {trigger: TRIGGERS.DRAG_STARTED, id: focusedItemId, source: SOURCES.KEYBOARD});
         triggerAllDzsUpdate();

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -309,8 +309,7 @@ export function dndzone(node, options) {
             dz => dzToConfig.get(dz).dropTargetClasses
         );
         if (!config.autoAriaDisabled) {
-            // The seat the item is lifted FROM, so a consumer can open with it ("Picked up
-            // Card A. To do, 1 of 5") — the most common reason to override this string.
+            // The seat the item is lifted FROM, so a consumer can open with it ("Picked up Card A. To do, 1 of 5")
             const startItems = dzToConfig.get(node).items;
             const startIdx = startItems.findIndex(item => item[ITEM_ID_KEY] === focusedItemId);
             announceToScreenReader("dragStarted", {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -95,7 +95,9 @@ export interface AriaStrings {
 }
 
 /**
- * Overrides the strings the library speaks to screen readers. Merges over the current strings.
+ * Overrides the strings the library speaks to screen readers. Merges over the built-in English defaults,
+ * so each call describes a whole locale rather than patching the previous one - anything a call leaves
+ * out goes back to English.
  * This is global and applies to all dndzones.
  * Pass null to restore the built-in English strings.
  */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -82,6 +82,22 @@ export interface DndZoneAttributes<T> {
  */
 export declare function alertToScreenReader(txt: string): void;
 
+export interface AriaStrings {
+    dragStarted?: (ctx: {itemLabel: string; zoneLabel: string; canMoveBetweenZones: boolean}) => string;
+    movedToPosition?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
+    movedToZoneEnd?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
+    movedToZoneStart?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
+    dropped?: (ctx: {itemLabel: string}) => string;
+    zoneActiveInstruction?: string;
+    zoneDragDisabledInstruction?: string;
+}
+
+/**
+ * Overrides the strings the library speaks to screen readers. Merges over the current strings.
+ * Pass null to restore the built-in English strings.
+ */
+export declare function setAriaStrings(overrides: AriaStrings | null): void;
+
 /**
  * Allows using another key instead of "id" in the items data. This is global and applies to all dndzones.
  * Has to be called when there are no rendered dndzones whatsoever.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -94,6 +94,7 @@ export interface AriaStrings {
 
 /**
  * Overrides the strings the library speaks to screen readers. Merges over the current strings.
+ * This is global and applies to all dndzones.
  * Pass null to restore the built-in English strings.
  */
 export declare function setAriaStrings(overrides: AriaStrings | null): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -82,12 +82,14 @@ export interface DndZoneAttributes<T> {
  */
 export declare function alertToScreenReader(txt: string): void;
 
+// Every message key receives the same core context - itemLabel, zoneLabel, position, count -
+// so a consumer can word any of them positionally. Only dragStarted carries an extra.
 export interface AriaStrings {
-    dragStarted?: (ctx: {itemLabel: string; zoneLabel: string; canMoveBetweenZones: boolean}) => string;
+    dragStarted?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number; canMoveBetweenZones: boolean}) => string;
     movedToPosition?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
     movedToZoneEnd?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
     movedToZoneStart?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
-    dropped?: (ctx: {itemLabel: string}) => string;
+    dropped?: (ctx: {itemLabel: string; zoneLabel: string; position: number; count: number}) => string;
     zoneActiveInstruction?: string;
     zoneDragDisabledInstruction?: string;
 }


### PR DESCRIPTION
### The problem

Today the only way to change the screen-reader wording is `autoAriaDisabled`, which is all-or-nothing — it turns off the aria attributes, roles and instructions along with the alerts, so a consumer who just wants French has to re-implement the whole accessibility layer via `consider`/`finalize`.

### The change

A new exported `setAriaStrings(overrides)` that merges over the string table the library speaks from:

```javascript
import {setAriaStrings} from "svelte-dnd-action";

setAriaStrings({
    dropped: ({itemLabel, zoneLabel, position, count}) => `${itemLabel} déposé dans ${zoneLabel}, ${position} sur ${count}`
});
```

- Seven keys, all optional — anything you leave out keeps its English default. The five message keys (`dragStarted`, `movedToPosition`, `movedToZoneEnd`, `movedToZoneStart`, `dropped`) are **functions** taking a context object, so consumers control word order and pluralisation rather than filling in blanks in an English sentence. The two instruction keys (`zoneActiveInstruction`, `zoneDragDisabledInstruction`) are plain strings.
- **Every message key receives the same context**: `itemLabel` and `zoneLabel` (from the `aria-label`s the consumer already provides), plus `position` and `count` — the item's 1-based seat in the zone the message is about, and how many items that zone holds. `dragStarted` additionally gets `canMoveBetweenZones`. The built-in English strings don't interpolate every field, but they are all supplied so any message can be worded positionally. Without that, a consumer can't say `Picked up Card A. To do, 1 of 5` on a grab, or name where an item came to rest on a drop.
- Callable at any time, including on a locale change - the static instruction divs already in the DOM are re-rendered. `setAriaStrings(null)` restores the built-in English.
- Validates the whole overrides object before applying any of it, so an unknown key or a wrong-typed value throws immediately and never leaves a half-applied table behind. Follows the error-message style of `setDebugMode`/`overrideItemIdKeyNameBeforeInitialisingDndZones`.
- A consumer formatter that throws is contained: `announceToScreenReader` falls back to the built-in default for that key and reports via `printDebug`. These run inside the drag lifecycle (e.g. `handleDrop`), so letting an exception escape would strand the library mid-drag.
- The instruction divs now render via `textContent` instead of `innerHTML`, since the text can now come from the consumer.

Behaviour is unchanged for anyone who doesn't call it — the defaults are the current strings verbatim, and the two callsites that gained context (`dragStarted`, `dropped`) read the seat off the same live items array the move messages already used.

### Docs & types

README gets a "Translating the screen-reader messages" section under accessibility, and the `autoAriaDisabled` row points at `setAriaStrings` for the wording-only case. `AriaStrings` and `setAriaStrings` are added to `typings/index.d.ts`.

### Tests

New `cypress/integration/aria.spec.js` (11 tests) covering defaults, partial merge, re-render of live instructions, reset via `null`, each validation error, and the throwing-formatter fallback. `keyboardAction.spec.js` gains coverage that the keyboard paths route through the table — including both branches of the cross-zone announcement (end vs. beginning), the `canMoveBetweenZones` branch of `dragStarted`, and that the grab and the drop are handed the item's real seat and the zone's real size. That last one grabs the middle card of a three-card zone on purpose: in a single-item zone a hardcoded position of `1` would pass either way.

`yarn lint`, `yarn build` and the full `yarn test` suite (60 passing) are green on top of current master.
