### PR TITLE
chore: prepare release 0.9.77

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you want to implement your own custom screen-reader alerts, roles and instruc
 
 #### Translating the screen-reader messages
 
-`autoAriaDisabled` is all-or-nothing — it turns off the aria attributes, the roles and the instructions along with the alerts. If all you want is to change the _words_ (for example to ship the library in a language other than English), import `setAriaStrings` instead and keep everything else:
+`autoAriaDisabled` disables all automatically added ARIA attributes, roles, instructions and alerts. If you only want to translate the screen-reader wording, import `setAriaStrings` and leave `autoAriaDisabled` off:
 
 ```javascript
 import {setAriaStrings} from "svelte-dnd-action";
@@ -181,16 +181,18 @@ setAriaStrings({
     movedToPosition: ({itemLabel, zoneLabel, position}) => `${itemLabel} déplacé en position ${position} dans la liste ${zoneLabel}`,
     movedToZoneEnd: ({itemLabel, zoneLabel}) => `${itemLabel} déplacé à la fin de la liste ${zoneLabel}`,
     movedToZoneStart: ({itemLabel, zoneLabel}) => `${itemLabel} déplacé au début de la liste ${zoneLabel}`,
-    // The defaults don't say where the item landed, but the context is there if you want it
+    // The default message omits the destination, but custom messages can include it
     dropped: ({itemLabel, zoneLabel, position, count}) => `${itemLabel} déposé dans ${zoneLabel}, ${position} sur ${count}`,
     zoneActiveInstruction: `Tabulez jusqu'à un élément et appuyez sur espace ou entrée pour le déplacer`,
     zoneDragDisabledInstruction: `Cette liste de glisser-déposer est désactivée`
 });
 ```
 
-Every key is optional — what you leave out keeps its English default. The five message keys are functions so that you control word order and pluralisation. All five receive the same context: `itemLabel` and `zoneLabel` (from the `aria-label` attributes you already provide), plus `position` and `count` — the item's 1-based seat in the zone the message is about, and how many items that zone holds. `dragStarted` additionally receives `canMoveBetweenZones`. Destructure only what your wording needs — the built-in English strings don't interpolate every field, but they are all supplied so you can word any message positionally, as the `dropped` line above does.
+Every key is optional. Omitted keys use their English defaults. The five announcement keys are formatter functions, so translations can control word order and pluralisation. Each formatter receives `itemLabel` and `zoneLabel` from the consumer-provided `aria-label` attributes, plus `position` and `count` for the item's 1-based position and the number of items in the relevant zone. `dragStarted` also receives `canMoveBetweenZones`. Destructure only the fields your wording needs; the built-in English messages do not use every field, but custom messages can.
 
-You can call it again whenever the user changes language — the static instructions already in the DOM are re-rendered too. Each call describes a whole locale rather than patching the previous one: the overrides are merged over the English defaults, not over whatever was set last, so a key your new locale is silent about goes back to English instead of staying in the old language. Pass `null` to go back to the built-in English. Passing an unrecognised key, or a value of the wrong type for its key, throws, so mistakes surface immediately. This is global and applies to all dndzones — you can't configure two zones with different aria strings.
+Call `setAriaStrings` during app-level initialization and again whenever the application locale changes. Each call defines the complete active locale by applying its overrides to the English defaults, so omitted keys return to English rather than retaining values from the previous locale. Existing instruction elements update immediately. Pass `null` to restore all English defaults. Unknown keys and values of the wrong type throw an error.
+
+The setting is global to the document and applies to every dndzone. Different zones cannot use different strings at the same time.
 
 ##### Keyboard support
 

--- a/cypress/integration/aria.spec.js
+++ b/cypress/integration/aria.spec.js
@@ -56,23 +56,19 @@ describe("aria strings", () => {
     });
 
     it("throws on an unknown key and names the supported ones", () => {
-        // Note: matched via substring rather than `.to.throw(/regex/)` - the Cypress version pinned in this
-        // repo (15.18.1) has a bug where chai's throw assertion never matches a RegExp errMsgMatcher, even
-        // for a bare `throw new Error(...)` with no involvement of this library's code.
+        // Cypress 15.18.1 does not match RegExp error assertions reliably, so compare substrings.
         expect(() => setAriaStrings({onDrop: () => "nope"})).to.throw("onDrop");
         expect(() => setAriaStrings({onDrop: () => "nope"})).to.throw("movedToPosition");
     });
 
     it("throws when a message key is given a non-function value", () => {
-        // A locale file missing a key would otherwise silently install `undefined`, and the screen
-        // reader would speak the literal word "undefined" on every drop.
+        // Missing translation entries often produce undefined; reject them before they can be announced.
         expect(() => setAriaStrings({dropped: undefined})).to.throw("dropped");
         expect(() => setAriaStrings({dropped: "Stopped dragging"})).to.throw("dropped");
     });
 
     it("throws when an instruction key is given a non-string value", () => {
-        // A natural mistake since the other five keys are functions - this would otherwise read the
-        // literal source text of the function aloud to every screen-reader user who tabs into a zone.
+        // Instruction keys are strings; reject formatter functions instead of exposing their source text.
         expect(() => setAriaStrings({zoneActiveInstruction: () => "Tab to an item"})).to.throw("zoneActiveInstruction");
     });
 
@@ -91,7 +87,7 @@ describe("aria strings", () => {
     });
 
     it("throws a clear error for non-object arguments instead of silently no-oping", () => {
-        // null/undefined are the legitimate "reset to defaults" signal and must keep working.
+        // null and undefined reset the active strings to their defaults.
         expect(() => setAriaStrings(42)).to.throw("42");
         expect(() => setAriaStrings([])).to.throw("setAriaStrings");
         expect(() => setAriaStrings("fr")).to.throw("setAriaStrings");
@@ -103,10 +99,7 @@ describe("aria strings", () => {
     });
 
     it("treats each call as a whole locale, not a patch on the previous one", () => {
-        // Switching locale exercises three kinds of key at once, and only the first survives a merge
-        // over the *current* table: one both locales name, one only the new locale names, and one only
-        // the old locale named. That last kind is the leak - two locale files rarely override the exact
-        // same subset, so the keys the new one is silent about would keep speaking the old language.
+        // Cover keys shared by both locales and keys supplied by only one locale.
         setAriaStrings({
             dropped: ({itemLabel}) => `${itemLabel} déposé`,
             zoneActiveInstruction: "Tabulez jusqu'à un élément et appuyez sur espace"

--- a/cypress/integration/keyboardAction.spec.js
+++ b/cypress/integration/keyboardAction.spec.js
@@ -262,9 +262,7 @@ describe("keyboardAction", () => {
             second.dispatchEvent(new KeyboardEvent("keydown", {key: " ", bubbles: true, cancelable: true}));
             seen.push(alertText());
 
-            // Lifted from seat 2 of 3 and dropped into seat 3 of 3. Both are read off the live
-            // items rather than assumed, so a hardcoded position or a stale count fails here
-            // instead of passing quietly - which a single-item zone would not catch.
+            // Multiple items ensure that hardcoded positions and stale counts fail the assertion.
             expect(seen).to.deep.equal(["grab:To do:2:3", "drop:To do:3:3"]);
         });
 
@@ -287,11 +285,7 @@ describe("keyboardAction", () => {
             });
             const {zone: zoneA, children: itemsA} = createLabelledZone([{id: "a"}], "To do");
             const {zone: zoneB} = createLabelledZone([{id: "b"}], "Done");
-            // The zones otherwise have no visible content, so both would collapse to the same
-            // (0,0) top/left and handleZoneFocus's `top <`/`left <` check would never fire true
-            // either direction. Give them real, distinct layout so zoneA genuinely sits above
-            // zoneB - that's what makes the two branches (movedToZoneStart / movedToZoneEnd)
-            // actually distinguishable here.
+            // Give the zones distinct positions so both insertion branches are reachable.
             zoneA.style.height = "50px";
             zoneB.style.height = "50px";
 
@@ -339,9 +333,7 @@ describe("keyboardAction", () => {
             expect(zone.tabIndex, "the drop should have completed and restored the zone's tab index").to.equal(0);
             expect(item.tabIndex, "the drop should have completed and restored the item's tab index").to.equal(0);
 
-            // A fresh grab proves the library isn't wedged in isDragging:true - if it were, pressing
-            // space would be routed to another drop (handleKeyDown treats space-while-dragging as a
-            // drop), not a new drag-started announcement.
+            // Starting another drag verifies that the formatter error did not leave drag state active.
             setAriaStrings(null);
             grab(item);
             expect(alertText(), "a fresh grab afterwards should start a new drag rather than drop again").to.equal(
@@ -362,8 +354,7 @@ describe("keyboardAction", () => {
 
             grab(item);
 
-            // unregisterDropZone calls handleDrop synchronously when the focused zone is destroyed
-            // mid-drag; a throwing formatter must not break component teardown.
+            // Destroying the focused zone calls handleDrop synchronously; formatter errors must not interrupt teardown.
             expect(() => action.destroy()).to.not.throw();
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-dnd-action",
     "description": "*An awesome drag and drop library for Svelte 3 and 4 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.76",
+    "version": "0.9.77",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/isaacHagoel/svelte-dnd-action.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,13 @@
 ## Svelte Dnd Action - Release Notes
 
+### [0.9.77](https://github.com/isaacHagoel/svelte-dnd-action/pull/698)
+
+Feature: add `setAriaStrings` for localizing the built-in screen-reader instructions and keyboard-drag announcements.
+
+-   Override any subset of messages with formatter functions that receive item, zone, position and count context.
+-   Update the document-wide locale at runtime while keeping English defaults for omitted messages.
+-   Preserve the library's existing ARIA roles and behavior without enabling `autoAriaDisabled`.
+
 ### [0.9.76](https://github.com/isaacHagoel/svelte-dnd-action/pull/695)
 
 Bugfix: include the originating drop-zone label in keyboard drag announcements so screen-reader users hear the list name from drag start and while reordering within the list.

--- a/src/helpers/aria.js
+++ b/src/helpers/aria.js
@@ -115,18 +115,15 @@ export function alertToScreenReader(txt) {
 }
 
 /**
- * Overrides the strings the library speaks to screen readers. Merges over the built-in English defaults,
- * so you can translate one message without restating the rest. Each call describes a whole locale rather
- * than patching the previous one - anything a call leaves out goes back to English, so switching between
- * two partial locales can't leave keys behind speaking the old language. Can be called at any time -
- * including again on a locale change, which also re-renders the static instructions already in the DOM.
- * This is global and applies to all dndzones.
+ * Overrides the strings the library announces to screen readers. Each call starts with the built-in
+ * English defaults and applies the supplied overrides, so omitted keys return to English when the locale
+ * changes. Existing instruction elements update immediately. This setting is global to all dndzones.
  * Pass null to restore the built-in English strings.
  * @param {Object | null} overrides - any subset of: dragStarted, movedToPosition, movedToZoneEnd,
  * movedToZoneStart, dropped (functions taking a context object and returning a string);
  * zoneActiveInstruction, zoneDragDisabledInstruction (strings)
- * @throws {Error} if given something other than an object or null, an unknown key, or a value of the wrong
- * type for its key (a partially-applied table is never left behind - the whole call is validated first)
+ * @throws {Error} if overrides is not an object or null, contains an unknown key, or contains a value of
+ * the wrong type. Validation completes before the active strings change.
  */
 export function setAriaStrings(overrides) {
     if (overrides === null || overrides === undefined) {
@@ -162,11 +159,9 @@ function formatAriaString(strings, key, ctx) {
 }
 
 /**
- * Formats one of the aria strings and alerts it to the screen reader. A consumer-supplied formatter
- * (installed via setAriaStrings) is never allowed to throw out of here - this runs inside the drag
- * lifecycle (ex: handleDrop), and letting an exception escape would leave the library stuck mid-drag.
- * If the consumer's formatter throws, we fall back to the built-in default for that key (itself guarded)
- * and report the swallowed error via printDebug.
+ * Formats and announces one configured ARIA message. If a consumer formatter throws, the built-in
+ * English formatter is used and the error is reported through printDebug. Formatter errors must not
+ * escape because this function runs during the drag lifecycle.
  * @param {string} key - one of the keys accepted by setAriaStrings
  * @param {Object} [ctx] - the interpolation context for that key
  */

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -165,9 +165,7 @@ function handleDrop(dispatchConsider = true) {
     if (!droppedConfig) return;
 
     if (!droppedConfig.autoAriaDisabled) {
-        // Same context as the move messages: where the item came to rest is the news, and a
-        // consumer that words the drop ("Dropped in Done, 2 of 5") needs the zone and the
-        // seat, not just the item. `focusedDzLabel` tracks focusedDz, which droppedDz is.
+        // Include the destination and final position so localized messages can describe the completed drop.
         const droppedItems = droppedConfig.items;
         const droppedIdx = droppedItems.findIndex(item => item[ITEM_ID_KEY] === droppedItemId);
         announceToScreenReader("dropped", {
@@ -309,7 +307,7 @@ export function dndzone(node, options) {
             dz => dzToConfig.get(dz).dropTargetClasses
         );
         if (!config.autoAriaDisabled) {
-            // The seat the item is lifted FROM, so a consumer can open with it ("Picked up Card A. To do, 1 of 5")
+            // Include the starting position so localized messages can describe where the item was picked up.
             const startItems = dzToConfig.get(node).items;
             const startIdx = startItems.findIndex(item => item[ITEM_ID_KEY] === focusedItemId);
             announceToScreenReader("dragStarted", {


### PR DESCRIPTION
## Summary

- bump the package version to `0.9.77`
- document the screen-reader localization feature from #698 in the release notes
- add app-level locale initialization guidance and clarify the document-wide scope
- tighten the new README, JSDoc and test comments without changing runtime behavior

## Why

PR #698 adds the public `setAriaStrings` API. This follow-up prepares that feature for publication and aligns its documentation with the project's existing writing style.

## Impact

Consumers get clear guidance for configuring and changing the application locale, including the English fallback behavior and the one-locale-per-document limitation.

## Validation

- `npm test` — 60 tests passing
- `yarn build` — lint and Rollup build passing
