### PR TITLE
docs: remove outdated Sushify plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SVELTE DND ACTION [![Known Vulnerabilities](https://snyk.io/test/github/isaacHagoel/svelte-dnd-action/badge.svg?targetFile=package.json)](https://snyk.io/test/github/isaacHagoel/svelte-dnd-action?targetFile=package.json)
 
-> Shameless plug: If you are making AI Apps check out my brand-new, open source [dev tool](https://github.com/pragmaticfish/sushify)
-
 This is a feature-complete implementation of drag and drop for Svelte using a custom action. It supports almost every imaginable drag and drop use-case, any input device and is fully accessible. <br />
 It requires very minimal configuration, while offering a rich set of primitives that allow overriding basically any of its default behaviours (using the handler functions). <br /><br />
 See full features list below. <br />


### PR DESCRIPTION
## Summary

Remove the outdated Sushify promotional link from the top of the README.

## Why

The linked developer tool is no longer relevant to this project.

## Impact

The README now opens directly with the `svelte-dnd-action` project description. Runtime code and package behavior are unchanged.

## Validation

- `npx prettier --check README.md`
