### PR TITLE
feat: add onActivate to hand Enter to the consumer (#511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ An options-object with the following attributes:
 | `centreDraggedOnCursor` | Boolean | No | `false` | Setting it to true will cause elements from this dnd-zone to position their center on the cursor on drag start, effectively turning the cursor to the focal point that triggers all the dnd events (ex: entering another zone). Useful for dnd-zones with large items that can be dragged over small items. |
 | `useCursorForDetection` | Boolean | No | `false` | Setting it to true will use the cursor position instead of the dragged element's center for drop zone detection. This improves accuracy when dragging large elements over small drop targets. Unlike `centreDraggedOnCursor`, this option does not reposition the dragged element. |
 | `dropAnimationDisabled` | Boolean | No | `false` | Setting it to true will disable the animation of the dropped element to its final place. |
+| `onActivate` | Function | No | `undefined` | Called with the item's id when _Enter_ is pressed on an item that is not being dragged.<br />Signature:<br />function(itemId) {}<br /><br />Supplying it hands _Enter_ to your app - for example to open the item - instead of starting a keyboard drag. The _Space_ key still starts a drag, so the zone remains keyboard-accessible. Omit it and _Enter_ keeps its default grab/drop behaviour. |
 | `delayTouchStart` | Boolean \| Number | No | `false` | Prevents accidental drags on touch devices that should have been scrolls.  
  • `true` – enable with sensible default (80 ms).  
  • `number` – custom delay in milliseconds.  
@@ -195,7 +196,7 @@ The setting is global to the document and applies to every dndzone. Different zo
 ##### Keyboard support
 
 -   Tab into a dnd container to get a description and instructions
--   Tab into an item and press the _Space_/_Enter_ key to enter dragging-mode. The reader will tell the user a drag has started.
+-   Tab into an item and press the _Space_/_Enter_ key to enter dragging-mode. The reader will tell the user a drag has started. If the zone supplies `onActivate`, _Enter_ is handed to your app instead and only _Space_ starts a drag.
 -   Use the _arrow keys_ while in dragging-mode to change the item's position in the list (down and right are the same, up and left are the same). The reader will tell the user about position changes.
 -   Tab to another dnd container while in dragging-mode in order to move the item to it (the item will be moved to it when it gets focus). The reader will tell the user that item was added to the new list.
 -   Press _Space_/_Enter_ key while focused on an item, or the _Escape_ key anywhere to exit dragging mode. The reader will tell the user that they are no longer dragging.

--- a/cypress/integration/keyboardOnActivate.spec.js
+++ b/cypress/integration/keyboardOnActivate.spec.js
@@ -1,0 +1,172 @@
+import {dndzone} from "../../src/keyboardAction";
+import {TRIGGERS} from "../../src/constants";
+
+describe("keyboardAction onActivate", () => {
+    const actions = [];
+    const zones = [];
+
+    function createZone(items, options = {}) {
+        const zone = document.createElement("div");
+        items.forEach(() => zone.appendChild(document.createElement("div")));
+        document.body.appendChild(zone);
+        zones.push(zone);
+        const action = dndzone(zone, {items, ...options});
+        actions.push(action);
+        return {zone, action, children: Array.from(zone.children)};
+    }
+
+    // A grab is observable as a DRAG_STARTED consider; that is what onActivate must suppress.
+    function grabsRecordedOn(zone) {
+        const grabs = [];
+        zone.addEventListener("consider", e => {
+            if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) grabs.push(e.detail.info.id);
+        });
+        return grabs;
+    }
+
+    function press(el, key) {
+        el.dispatchEvent(new KeyboardEvent("keydown", {key, bubbles: true, cancelable: true}));
+    }
+
+    afterEach(() => {
+        actions
+            .splice(0)
+            .reverse()
+            .forEach(action => action.destroy());
+        zones.splice(0).forEach(zone => zone.remove());
+    });
+
+    describe("when the consumer opts in", () => {
+        it("calls onActivate with the item id instead of grabbing", () => {
+            const activated = [];
+            const {
+                zone,
+                children: [, second]
+            } = createZone([{id: "a"}, {id: "b"}], {onActivate: id => activated.push(id)});
+            const grabs = grabsRecordedOn(zone);
+
+            press(second, "Enter");
+
+            expect(activated, "Enter should activate the focused item").to.deep.equal(["b"]);
+            expect(grabs, "Enter must not start a drag when onActivate is provided").to.deep.equal([]);
+        });
+
+        it("leaves Space grabbing, so a drag is still reachable from the keyboard", () => {
+            const activated = [];
+            const {
+                zone,
+                children: [item]
+            } = createZone([{id: "a"}, {id: "b"}], {onActivate: id => activated.push(id)});
+            const grabs = grabsRecordedOn(zone);
+
+            press(item, " ");
+
+            expect(grabs, "Space should still grab").to.deep.equal(["a"]);
+            expect(activated, "Space must not activate").to.deep.equal([]);
+        });
+
+        it("drops on Enter while a drag is in progress rather than activating", () => {
+            const activated = [];
+            const {
+                zone,
+                children: [item]
+            } = createZone([{id: "a"}, {id: "b"}], {onActivate: id => activated.push(id)});
+            const stops = [];
+            zone.addEventListener("consider", e => {
+                if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) stops.push(e.detail.info.id);
+            });
+
+            press(item, " ");
+            press(item, "Enter");
+
+            expect(stops, "Enter should end an in-progress drag").to.deep.equal(["a"]);
+            expect(activated, "Enter must not activate while dragging").to.deep.equal([]);
+        });
+
+        it("is picked up when supplied by a later update rather than at init", () => {
+            const activated = [];
+            const {
+                zone,
+                action,
+                children: [item]
+            } = createZone([{id: "a"}, {id: "b"}]);
+            const grabs = grabsRecordedOn(zone);
+
+            action.update({items: [{id: "a"}, {id: "b"}], onActivate: id => activated.push(id)});
+            press(item, "Enter");
+
+            expect(activated).to.deep.equal(["a"]);
+            expect(grabs).to.deep.equal([]);
+        });
+
+        it("stops activating again once a later update removes it", () => {
+            const activated = [];
+            const {
+                zone,
+                action,
+                children: [item]
+            } = createZone([{id: "a"}, {id: "b"}], {onActivate: id => activated.push(id)});
+            const grabs = grabsRecordedOn(zone);
+
+            action.update({items: [{id: "a"}, {id: "b"}]});
+            press(item, "Enter");
+
+            expect(activated, "the removed handler must not be called").to.deep.equal([]);
+            expect(grabs, "Enter should go back to grabbing").to.deep.equal(["a"]);
+        });
+
+        it("does not activate from a nested interactive element", () => {
+            const activated = [];
+            const {
+                children: [item]
+            } = createZone([{id: "a"}], {onActivate: id => activated.push(id)});
+            const button = document.createElement("button");
+            item.appendChild(button);
+
+            press(button, "Enter");
+
+            expect(activated, "the button's own Enter must reach the button, not the zone").to.deep.equal([]);
+        });
+
+        it("does not activate when dragDisabled is set", () => {
+            const activated = [];
+            const {
+                children: [item]
+            } = createZone([{id: "a"}], {onActivate: id => activated.push(id), dragDisabled: true});
+
+            press(item, "Enter");
+
+            expect(activated, "dragDisabled removes the keydown listener entirely").to.deep.equal([]);
+        });
+    });
+
+    describe("when the consumer does not opt in", () => {
+        it("keeps Enter grabbing", () => {
+            const {
+                zone,
+                children: [item]
+            } = createZone([{id: "a"}, {id: "b"}]);
+            const grabs = grabsRecordedOn(zone);
+
+            press(item, "Enter");
+
+            expect(grabs, "stock behaviour must be unchanged when onActivate is absent").to.deep.equal(["a"]);
+        });
+
+        it("keeps Enter dropping an in-progress drag", () => {
+            const {
+                zone,
+                children: [item]
+            } = createZone([{id: "a"}, {id: "b"}]);
+            const stops = [];
+            zone.addEventListener("consider", e => {
+                if (e.detail.info.trigger === TRIGGERS.DRAG_STOPPED) stops.push(e.detail.info.id);
+            });
+
+            press(item, " ");
+            press(item, "Enter");
+
+            expect(stops).to.deep.equal(["a"]);
+        });
+    });
+});

--- a/src/action.js
+++ b/src/action.js
@@ -80,6 +80,7 @@ function validateOptions(options) {
         useCursorForDetection,
         delayTouchStart,
         dropAnimationDisabled,
+        onActivate,
         ...rest
     } = options;
     /*eslint-enable*/

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -217,7 +217,8 @@ export function dndzone(node, options) {
         dropFromOthersDisabled: false,
         dropTargetStyle: DEFAULT_DROP_TARGET_STYLE,
         dropTargetClasses: [],
-        autoAriaDisabled: false
+        autoAriaDisabled: false,
+        onActivate: undefined
     };
 
     function swap(arr, i, j) {
@@ -236,6 +237,16 @@ export function dndzone(node, options) {
                 }
                 e.preventDefault(); // preventing scrolling on spacebar
                 e.stopPropagation();
+                // Opt-in split activation: when the consumer supplies onActivate, Enter on an
+                // item that is not being dragged belongs to them (ex: open it) rather than
+                // starting a drag. Space still grabs, so keyboard dragging stays reachable and
+                // the zone stays accessible. Without onActivate, Enter keeps its stock behaviour.
+                if (e.key === "Enter" && !isDragging && config.onActivate) {
+                    const {items} = dzToConfig.get(node);
+                    const idx = Array.from(node.children).indexOf(e.currentTarget);
+                    if (idx >= 0 && items[idx]) config.onActivate(items[idx][ITEM_ID_KEY]);
+                    return;
+                }
                 if (isDragging) {
                     // TODO - should this trigger a drop? only here or in general (as in when hitting space or enter outside of any zone)?
                     handleDrop();
@@ -348,7 +359,8 @@ export function dndzone(node, options) {
         dropFromOthersDisabled = false,
         dropTargetStyle = DEFAULT_DROP_TARGET_STYLE,
         dropTargetClasses = [],
-        autoAriaDisabled = false
+        autoAriaDisabled = false,
+        onActivate = undefined
     }) {
         config.items = [...items];
         config.dragDisabled = dragDisabled;
@@ -358,6 +370,7 @@ export function dndzone(node, options) {
         config.dropTargetStyle = dropTargetStyle;
         config.dropTargetClasses = dropTargetClasses;
         config.autoAriaDisabled = autoAriaDisabled;
+        config.onActivate = onActivate;
         if (config.type && newType !== config.type) {
             unregisterDropZone(node, config.type);
         }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -68,6 +68,12 @@ export interface Options<T extends Item = Item> {
      * Use cursor position instead of dragged element center for drop zone detection
      */
     useCursorForDetection?: boolean;
+    /**
+     * Called with the item's id when Enter is pressed on an item that is not being dragged.
+     * Supplying it hands Enter to your app (ex: open the item) instead of starting a keyboard
+     * drag; space-bar still starts one. Omit it to keep Enter's default grab/drop behaviour.
+     */
+    onActivate?: (itemId: string) => void;
 }
 
 export interface DndZoneAttributes<T> {


### PR DESCRIPTION
Adds an optional `onActivate` so a consumer can take the _Enter_ key for their own use without giving up keyboard drag and drop.

When `onActivate` is supplied, pressing _Enter_ on an item that is not being dragged calls it with that item's id instead of starting a drag. _Space_ still starts a drag, so the zone stays keyboard-accessible. Omit the option and _Enter_ behaves exactly as it does today.

```js
use:dndzone={{items, onActivate: id => openItem(id)}}
```

### Why

#511 asks for a way to reassign or free up _Space_/_Enter_. The concrete case there is a playlist where _Enter_ should play the focused item; you replied that you were open to a PR adding customisation of that sort.

The part that seems worth fixing is what people do in the meantime. In that thread the reported workarounds are setting `tabindex="-1"` on every zone and item and wrapping the whole thing in custom listeners, or dropping `keyboardAction.js` altogether. Both are strictly less accessible than the library's own handling. This option removes the reason to reach for them: the consumer gets _Enter_, and the library keeps announcing, managing focus and driving the drag from _Space_.

It is deliberately not a general key-remapping API. _Enter_ is the one key with a genuine conflict, because it is the conventional "activate this thing" key and is doubled with _Space_ here — so handing it over costs no capability. I am happy to take this further toward configurable keys if you would prefer that shape.

### Implementation notes

- The check sits inside the existing shared `Enter`/`" "` case rather than splitting `Enter` into its own case, so the nested-interactive-element guard, `preventDefault` and `stopPropagation` all keep applying unchanged. The diff is one guard clause.
- It reads the item id from the zone's `items` rather than going through `setCurrentFocusedItem`, so an activation leaves the module's drag state untouched — no `focusedItem`/`focusedItemId` set while `isDragging` is false.
- `onActivate` is threaded through `configure()` like the other options, so it can be added or removed by a later update.
- `src/action.js` gains the option in `validateOptions`' destructure so it is not rejected as unknown.

### Tests

`cypress/integration/keyboardOnActivate.spec.js`, 9 cases covering both directions:

- with the option: _Enter_ activates and does not grab; _Space_ still grabs; _Enter_ still drops an in-progress drag
- without it: _Enter_ grabs, and drops an in-progress drag, as before
- the handler being added and removed through `update()`
- a nested `<button>` keeping its own _Enter_
- `dragDisabled` suppressing activation

`yarn lint` and the full `yarn test` suite pass (69 tests).

Docs: new row in the options table plus a note on the existing keyboard-support bullet, and the type in `typings/index.d.ts`.
